### PR TITLE
Add toBeNear in text-editor-component-spec

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -262,6 +262,9 @@ addCustomMatchers = (spec) ->
       @message = -> return "Expected path '#{actualPath}' to be equal to '#{expectedPath}'."
       actualPath is expectedPath
 
+    toBeNear: (expected, acceptedError = 1, actual) ->
+      return (typeof expected is 'number') and (typeof acceptedError is 'number') and (typeof @actual is 'number') and (expected - acceptedError <= @actual) and (@actual <= expected + acceptedError)
+
 window.waitsForPromise = (args...) ->
   label = null
   if args.length > 1

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -265,6 +265,11 @@ addCustomMatchers = (spec) ->
     toBeNear: (expected, acceptedError = 1, actual) ->
       return (typeof expected is 'number') and (typeof acceptedError is 'number') and (typeof @actual is 'number') and (expected - acceptedError <= @actual) and (@actual <= expected + acceptedError)
 
+    toHaveNearPixels: (expected, acceptedError = 1, actual) ->
+      expectedNumber =  parseInt(expected, 10)
+      actualNumber =  parseInt(@actual, 10)
+      return (typeof expected is 'string') and (typeof acceptedError is 'number') and (typeof @actual is 'string') and (expected.indexOf('px') >= 1) and (@actual.indexOf('px') >= 1) and (expectedNumber - acceptedError <= actualNumber) and (actualNumber <= expectedNumber + acceptedError)
+
 window.waitsForPromise = (args...) ->
   label = null
   if args.length > 1

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -266,8 +266,8 @@ addCustomMatchers = (spec) ->
       return (typeof expected is 'number') and (typeof acceptedError is 'number') and (typeof @actual is 'number') and (expected - acceptedError <= @actual) and (@actual <= expected + acceptedError)
 
     toHaveNearPixels: (expected, acceptedError = 1, actual) ->
-      expectedNumber =  parseInt(expected, 10)
-      actualNumber =  parseInt(@actual, 10)
+      expectedNumber =  parseFloat(expected)
+      actualNumber =  parseFloat(@actual)
       return (typeof expected is 'string') and (typeof acceptedError is 'number') and (typeof @actual is 'string') and (expected.indexOf('px') >= 1) and (@actual.indexOf('px') >= 1) and (expectedNumber - acceptedError <= actualNumber) and (actualNumber <= expectedNumber + acceptedError)
 
 window.waitsForPromise = (args...) ->

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -239,8 +239,9 @@ describe('TextEditorComponent', () => {
       editor.setText('a\n'.repeat(30));
       await component.getNextUpdatePromise();
       expect(component.refs.content.offsetHeight).toBeGreaterThan(100);
-      expect(component.refs.content.offsetHeight).toBe(
-        component.getContentHeight()
+      expect(component.refs.content.offsetHeight).toBeNear(
+        component.getContentHeight(),
+        2
       );
     });
 
@@ -302,7 +303,7 @@ describe('TextEditorComponent', () => {
 
       const lineNumberGutterElement =
         component.refs.gutterContainer.refs.lineNumberGutter.element;
-      expect(lineNumberGutterElement.offsetHeight).toBe(
+      expect(lineNumberGutterElement.offsetHeight).toBeNear(
         component.getScrollHeight()
       );
 
@@ -319,7 +320,7 @@ describe('TextEditorComponent', () => {
 
       editor.setText('x\n'.repeat(99));
       await component.getNextUpdatePromise();
-      expect(lineNumberGutterElement.offsetHeight).toBe(
+      expect(lineNumberGutterElement.offsetHeight).toBeNear(
         component.getScrollHeight()
       );
       for (const child of lineNumberGutterElement.children) {
@@ -412,8 +413,12 @@ describe('TextEditorComponent', () => {
       });
       const verticalScrollbar = component.refs.verticalScrollbar.element;
       const horizontalScrollbar = component.refs.horizontalScrollbar.element;
-      expect(verticalScrollbar.scrollHeight).toBe(component.getContentHeight());
-      expect(horizontalScrollbar.scrollWidth).toBe(component.getContentWidth());
+      expect(verticalScrollbar.scrollHeight).toBeNear(
+        component.getContentHeight()
+      );
+      expect(horizontalScrollbar.scrollWidth).toBeNear(
+        component.getContentWidth()
+      );
       expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0);
       expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0);
       expect(verticalScrollbar.style.bottom).toBe(
@@ -479,18 +484,20 @@ describe('TextEditorComponent', () => {
         TextEditor.didUpdateScrollbarStyles();
         await component.getNextUpdatePromise();
 
-        expect(getHorizontalScrollbarHeight(component)).toBe(10);
-        expect(getVerticalScrollbarWidth(component)).toBe(10);
+        expect(getHorizontalScrollbarHeight(component)).toBeNear(10);
+        expect(getVerticalScrollbarWidth(component)).toBeNear(10);
         expect(component.refs.horizontalScrollbar.element.style.right).toBe(
           '10px'
         );
         expect(component.refs.verticalScrollbar.element.style.bottom).toBe(
           '10px'
         );
-        expect(component.refs.horizontalScrollbar.element.scrollLeft).toBe(10);
-        expect(component.refs.verticalScrollbar.element.scrollTop).toBe(20);
-        expect(component.getScrollContainerClientHeight()).toBe(100 - 10);
-        expect(component.getScrollContainerClientWidth()).toBe(
+        expect(component.refs.horizontalScrollbar.element.scrollLeft).toBeNear(
+          10
+        );
+        expect(component.refs.verticalScrollbar.element.scrollTop).toBeNear(20);
+        expect(component.getScrollContainerClientHeight()).toBeNear(100 - 10);
+        expect(component.getScrollContainerClientWidth()).toBeNear(
           100 - component.getGutterContainerWidth() - 10
         );
 
@@ -498,18 +505,20 @@ describe('TextEditorComponent', () => {
         element.remove();
         jasmine.attachToDOM(element);
 
-        expect(getHorizontalScrollbarHeight(component)).toBe(10);
-        expect(getVerticalScrollbarWidth(component)).toBe(10);
+        expect(getHorizontalScrollbarHeight(component)).toBeNear(10);
+        expect(getVerticalScrollbarWidth(component)).toBeNear(10);
         expect(component.refs.horizontalScrollbar.element.style.right).toBe(
           '10px'
         );
         expect(component.refs.verticalScrollbar.element.style.bottom).toBe(
           '10px'
         );
-        expect(component.refs.horizontalScrollbar.element.scrollLeft).toBe(10);
-        expect(component.refs.verticalScrollbar.element.scrollTop).toBe(20);
-        expect(component.getScrollContainerClientHeight()).toBe(100 - 10);
-        expect(component.getScrollContainerClientWidth()).toBe(
+        expect(component.refs.horizontalScrollbar.element.scrollLeft).toBeNear(
+          10
+        );
+        expect(component.refs.verticalScrollbar.element.scrollTop).toBeNear(20);
+        expect(component.getScrollContainerClientHeight()).toBeNear(100 - 10);
+        expect(component.getScrollContainerClientWidth()).toBeNear(
           100 - component.getGutterContainerWidth() - 10
         );
 
@@ -815,7 +824,7 @@ describe('TextEditorComponent', () => {
           verticalScrollbarWidth +
           2 * editorPadding
       );
-      expect(initialHeight).toBe(
+      expect(initialHeight).toBeNear(
         component.getContentHeight() +
           horizontalScrollbarHeight +
           2 * editorPadding
@@ -836,7 +845,7 @@ describe('TextEditorComponent', () => {
       // When autoHeight is enabled, height adjusts to content
       editor.insertText('\n'.repeat(5));
       await component.getNextUpdatePromise();
-      expect(element.offsetHeight).toBe(
+      expect(element.offsetHeight).toBeNear(
         component.getContentHeight() +
           horizontalScrollbarHeight +
           2 * editorPadding
@@ -854,7 +863,7 @@ describe('TextEditorComponent', () => {
     it('does not render the line numbers but still renders the line number gutter if showLineNumbers is false', async () => {
       function checkScrollContainerLeft(component) {
         const { scrollContainer, gutterContainer } = component.refs;
-        expect(scrollContainer.getBoundingClientRect().left).toBe(
+        expect(scrollContainer.getBoundingClientRect().left).toBeNear(
           Math.round(gutterContainer.element.getBoundingClientRect().right)
         );
       }
@@ -1394,20 +1403,20 @@ describe('TextEditorComponent', () => {
 
       editor.scrollToScreenRange([[4, 0], [6, 0]]);
       await component.getNextUpdatePromise();
-      expect(component.getScrollBottom()).toBe(
+      expect(component.getScrollBottom()).toBeNear(
         (6 + 1 + editor.verticalScrollMargin) * component.getLineHeight()
       );
 
       editor.scrollToScreenPosition([8, 0]);
       await component.getNextUpdatePromise();
-      expect(component.getScrollBottom()).toBe(
+      expect(component.getScrollBottom()).toBeNear(
         (8 + 1 + editor.verticalScrollMargin) *
           component.measurements.lineHeight
       );
 
       editor.scrollToScreenPosition([3, 0]);
       await component.getNextUpdatePromise();
-      expect(component.getScrollTop()).toBe(
+      expect(component.getScrollTop()).toBeNear(
         (3 - editor.verticalScrollMargin) * component.measurements.lineHeight
       );
 
@@ -1430,25 +1439,25 @@ describe('TextEditorComponent', () => {
 
       editor.scrollToScreenPosition([6, 0]);
       await component.getNextUpdatePromise();
-      expect(component.getScrollBottom()).toBe(
+      expect(component.getScrollBottom()).toBeNear(
         (6 + 1 + scrollMarginInLines) * component.measurements.lineHeight
       );
 
       editor.scrollToScreenPosition([6, 4]);
       await component.getNextUpdatePromise();
-      expect(component.getScrollBottom()).toBe(
+      expect(component.getScrollBottom()).toBeNear(
         (6 + 1 + scrollMarginInLines) * component.measurements.lineHeight
       );
 
       editor.scrollToScreenRange([[4, 4], [6, 4]]);
       await component.getNextUpdatePromise();
-      expect(component.getScrollTop()).toBe(
+      expect(component.getScrollTop()).toBeNear(
         (4 - scrollMarginInLines) * component.measurements.lineHeight
       );
 
       editor.scrollToScreenRange([[4, 4], [6, 4]], { reversed: false });
       await component.getNextUpdatePromise();
-      expect(component.getScrollBottom()).toBe(
+      expect(component.getScrollBottom()).toBeNear(
         (6 + 1 + scrollMarginInLines) * component.measurements.lineHeight
       );
     });
@@ -1516,7 +1525,7 @@ describe('TextEditorComponent', () => {
           Math.floor((editorWidthInChars - 1) / 2) *
             component.getBaseCharacterWidth()
       );
-      expect(component.getScrollLeft()).toBe(expectedScrollLeft);
+      expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
     });
 
     it('correctly autoscrolls after inserting a line that exceeds the current content width', async () => {
@@ -1531,7 +1540,7 @@ describe('TextEditorComponent', () => {
       editor.insertText('x'.repeat(100));
       await component.getNextUpdatePromise();
 
-      expect(component.getScrollLeft()).toBe(
+      expect(component.getScrollLeft()).toBeNear(
         component.getScrollWidth() - component.getScrollContainerClientWidth()
       );
     });
@@ -1545,7 +1554,7 @@ describe('TextEditorComponent', () => {
       editor.scrollToBufferPosition([11, 5]);
       editor.getBuffer().deleteRows(11, 12);
       await component.getNextUpdatePromise();
-      expect(component.getScrollBottom()).toBe(
+      expect(component.getScrollBottom()).toBeNear(
         (10 + 1) * component.measurements.lineHeight
       );
     });
@@ -1562,10 +1571,10 @@ describe('TextEditorComponent', () => {
       editor.insertText('\n\n' + 'x'.repeat(100));
       await component.getNextUpdatePromise();
 
-      expect(component.getScrollTop()).toBe(
+      expect(component.getScrollTop()).toBeNear(
         component.getScrollHeight() - component.getScrollContainerClientHeight()
       );
-      expect(component.getScrollLeft()).toBe(
+      expect(component.getScrollLeft()).toBeNear(
         component.getScrollWidth() - component.getScrollContainerClientWidth()
       );
 
@@ -1592,36 +1601,36 @@ describe('TextEditorComponent', () => {
       // Assigns the scrollTop based on the logical position when attached
       jasmine.attachToDOM(element);
       const expectedScrollTop = Math.round(6 * component.getLineHeight());
-      expect(component.getScrollTopRow()).toBe(6);
-      expect(component.getScrollTop()).toBe(expectedScrollTop);
+      expect(component.getScrollTopRow()).toBeNear(6);
+      expect(component.getScrollTop()).toBeNear(expectedScrollTop);
       expect(component.refs.content.style.transform).toBe(
         `translate(0px, -${expectedScrollTop}px)`
       );
 
       // Allows the scrollTopRow to be updated while attached
       component.setScrollTopRow(4);
-      expect(component.getScrollTopRow()).toBe(4);
-      expect(component.getScrollTop()).toBe(
+      expect(component.getScrollTopRow()).toBeNear(4);
+      expect(component.getScrollTop()).toBeNear(
         Math.round(4 * component.getLineHeight())
       );
 
       // Preserves the scrollTopRow when detached
       element.remove();
-      expect(component.getScrollTopRow()).toBe(4);
-      expect(component.getScrollTop()).toBe(
+      expect(component.getScrollTopRow()).toBeNear(4);
+      expect(component.getScrollTop()).toBeNear(
         Math.round(4 * component.getLineHeight())
       );
 
       component.setScrollTopRow(6);
-      expect(component.getScrollTopRow()).toBe(6);
-      expect(component.getScrollTop()).toBe(
+      expect(component.getScrollTopRow()).toBeNear(6);
+      expect(component.getScrollTop()).toBeNear(
         Math.round(6 * component.getLineHeight())
       );
 
       jasmine.attachToDOM(element);
       element.style.height = '60px';
-      expect(component.getScrollTopRow()).toBe(6);
-      expect(component.getScrollTop()).toBe(
+      expect(component.getScrollTopRow()).toBeNear(6);
+      expect(component.getScrollTop()).toBeNear(
         Math.round(6 * component.getLineHeight())
       );
     });
@@ -1691,8 +1700,8 @@ describe('TextEditorComponent', () => {
           wheelDeltaY: -20,
           preventDefault: eventPreventDefaultStub
         });
-        expect(component.getScrollTop()).toBe(expectedScrollTop);
-        expect(component.getScrollLeft()).toBe(expectedScrollLeft);
+        expect(component.getScrollTop()).toBeNear(expectedScrollTop);
+        expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
           `translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`
         );
@@ -1707,8 +1716,8 @@ describe('TextEditorComponent', () => {
           wheelDeltaY: 10,
           preventDefault: eventPreventDefaultStub
         });
-        expect(component.getScrollTop()).toBe(expectedScrollTop);
-        expect(component.getScrollLeft()).toBe(expectedScrollLeft);
+        expect(component.getScrollTop()).toBeNear(expectedScrollTop);
+        expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
           `translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`
         );
@@ -1722,8 +1731,8 @@ describe('TextEditorComponent', () => {
           wheelDeltaY: 10,
           preventDefault: eventPreventDefaultStub
         });
-        expect(component.getScrollTop()).toBe(expectedScrollTop);
-        expect(component.getScrollLeft()).toBe(expectedScrollLeft);
+        expect(component.getScrollTop()).toBeNear(expectedScrollTop);
+        expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
           `translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`
         );
@@ -1738,8 +1747,8 @@ describe('TextEditorComponent', () => {
           wheelDeltaY: -8,
           preventDefault: eventPreventDefaultStub
         });
-        expect(component.getScrollTop()).toBe(expectedScrollTop);
-        expect(component.getScrollLeft()).toBe(expectedScrollLeft);
+        expect(component.getScrollTop()).toBeNear(expectedScrollTop);
+        expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
           `translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`
         );
@@ -1764,7 +1773,7 @@ describe('TextEditorComponent', () => {
           wheelDeltaY: -20,
           preventDefault: eventPreventDefaultStub
         });
-        expect(component.getScrollTop()).toBe(expectedScrollTop);
+        expect(component.getScrollTop()).toBeNear(expectedScrollTop);
         expect(component.refs.content.style.transform).toBe(
           `translate(0px, -${expectedScrollTop}px)`
         );
@@ -1779,7 +1788,7 @@ describe('TextEditorComponent', () => {
           shiftKey: true,
           preventDefault: eventPreventDefaultStub
         });
-        expect(component.getScrollLeft()).toBe(expectedScrollLeft);
+        expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
           `translate(-${expectedScrollLeft}px, 0px)`
         );
@@ -1913,20 +1922,20 @@ describe('TextEditorComponent', () => {
       setScrollTop(component, NaN);
       setScrollLeft(component, NaN);
       await component.getNextUpdatePromise();
-      expect(component.getScrollTop()).toBe(initialScrollTop);
-      expect(component.getScrollLeft()).toBe(initialScrollLeft);
+      expect(component.getScrollTop()).toBeNear(initialScrollTop);
+      expect(component.getScrollLeft()).toBeNear(initialScrollLeft);
 
       setScrollTop(component, null);
       setScrollLeft(component, null);
       await component.getNextUpdatePromise();
-      expect(component.getScrollTop()).toBe(initialScrollTop);
-      expect(component.getScrollLeft()).toBe(initialScrollLeft);
+      expect(component.getScrollTop()).toBeNear(initialScrollTop);
+      expect(component.getScrollLeft()).toBeNear(initialScrollLeft);
 
       setScrollTop(component, undefined);
       setScrollLeft(component, undefined);
       await component.getNextUpdatePromise();
-      expect(component.getScrollTop()).toBe(initialScrollTop);
-      expect(component.getScrollLeft()).toBe(initialScrollLeft);
+      expect(component.getScrollTop()).toBeNear(initialScrollTop);
+      expect(component.getScrollLeft()).toBeNear(initialScrollLeft);
     });
   });
 
@@ -2304,10 +2313,10 @@ describe('TextEditorComponent', () => {
         );
 
         const region1Rect = regions[1].getBoundingClientRect();
-        expect(region1Rect.top).toBe(
+        expect(region1Rect.top).toBeNear(
           lineNodeForScreenRow(component, 3).getBoundingClientRect().top
         );
-        expect(region1Rect.bottom).toBe(
+        expect(region1Rect.bottom).toBeNear(
           lineNodeForScreenRow(component, 3).getBoundingClientRect().bottom
         );
         expect(Math.round(region1Rect.left)).toBeNear(
@@ -2328,10 +2337,10 @@ describe('TextEditorComponent', () => {
         expect(regions.length).toBe(3);
 
         const region0Rect = regions[0].getBoundingClientRect();
-        expect(region0Rect.top).toBe(
+        expect(region0Rect.top).toBeNear(
           lineNodeForScreenRow(component, 2).getBoundingClientRect().top
         );
-        expect(region0Rect.bottom).toBe(
+        expect(region0Rect.bottom).toBeNear(
           lineNodeForScreenRow(component, 2).getBoundingClientRect().bottom
         );
         expect(Math.round(region0Rect.left)).toBeNear(
@@ -2342,27 +2351,27 @@ describe('TextEditorComponent', () => {
         );
 
         const region1Rect = regions[1].getBoundingClientRect();
-        expect(region1Rect.top).toBe(
+        expect(region1Rect.top).toBeNear(
           lineNodeForScreenRow(component, 3).getBoundingClientRect().top
         );
-        expect(region1Rect.bottom).toBe(
+        expect(region1Rect.bottom).toBeNear(
           lineNodeForScreenRow(component, 5).getBoundingClientRect().top
         );
-        expect(Math.round(region1Rect.left)).toBe(
+        expect(Math.round(region1Rect.left)).toBeNear(
           component.refs.content.getBoundingClientRect().left
         );
-        expect(Math.round(region1Rect.right)).toBe(
+        expect(Math.round(region1Rect.right)).toBeNear(
           component.refs.content.getBoundingClientRect().right
         );
 
         const region2Rect = regions[2].getBoundingClientRect();
-        expect(region2Rect.top).toBe(
+        expect(region2Rect.top).toBeNear(
           lineNodeForScreenRow(component, 5).getBoundingClientRect().top
         );
-        expect(region2Rect.bottom).toBe(
+        expect(region2Rect.bottom).toBeNear(
           lineNodeForScreenRow(component, 6).getBoundingClientRect().top
         );
-        expect(Math.round(region2Rect.left)).toBe(
+        expect(Math.round(region2Rect.left)).toBeNear(
           component.refs.content.getBoundingClientRect().left
         );
         expect(Math.round(region2Rect.right)).toBeNear(
@@ -2542,9 +2551,9 @@ describe('TextEditorComponent', () => {
 
       await component.getNextUpdatePromise();
       const regions = element.querySelectorAll('.highlight .region');
-      expect(regions[0].offsetTop).toBe(3 * component.getLineHeight());
-      expect(regions[0].offsetHeight).toBe(component.getLineHeight());
-      expect(regions[1].offsetTop).toBe(4 * component.getLineHeight() + 30);
+      expect(regions[0].offsetTop).toBeNear(3 * component.getLineHeight());
+      expect(regions[0].offsetHeight).toBeNear(component.getLineHeight());
+      expect(regions[1].offsetTop).toBeNear(4 * component.getLineHeight() + 30);
     });
   });
 
@@ -2596,7 +2605,7 @@ describe('TextEditorComponent', () => {
 
       const overlayWrapper = overlayElement.parentElement;
       expect(overlayWrapper.classList.contains('a')).toBe(true);
-      expect(overlayWrapper.getBoundingClientRect().top).toBe(
+      expect(overlayWrapper.getBoundingClientRect().top).toBeNear(
         clientTopForLine(component, 5)
       );
       expect(overlayWrapper.getBoundingClientRect().left).toBeNear(
@@ -2612,17 +2621,17 @@ describe('TextEditorComponent', () => {
       // Shifts the overlay horizontally to ensure the overlay element does not
       // overflow the window
       await setScrollLeft(component, 30);
-      expect(overlayElement.getBoundingClientRect().right).toBe(
+      expect(overlayElement.getBoundingClientRect().right).toBeNear(
         fakeWindow.getBoundingClientRect().right
       );
       await setScrollLeft(component, 280);
-      expect(overlayElement.getBoundingClientRect().left).toBe(
+      expect(overlayElement.getBoundingClientRect().left).toBeNear(
         fakeWindow.getBoundingClientRect().left
       );
 
       // Updates the vertical position on scroll
       await setScrollTop(component, 60);
-      expect(overlayWrapper.getBoundingClientRect().top).toBe(
+      expect(overlayWrapper.getBoundingClientRect().top).toBeNear(
         clientTopForLine(component, 5)
       );
 
@@ -2630,25 +2639,25 @@ describe('TextEditorComponent', () => {
       // overflow the bottom of the window
       setScrollLeft(component, 100);
       await setScrollTop(component, 0);
-      expect(overlayWrapper.getBoundingClientRect().bottom).toBe(
+      expect(overlayWrapper.getBoundingClientRect().bottom).toBeNear(
         clientTopForLine(component, 4)
       );
 
       // Flips the overlay vertically on overlay resize if necessary
       await setScrollTop(component, 20);
-      expect(overlayWrapper.getBoundingClientRect().top).toBe(
+      expect(overlayWrapper.getBoundingClientRect().top).toBeNear(
         clientTopForLine(component, 5)
       );
       overlayElement.style.height = 60 + 'px';
       await overlayComponent.getNextUpdatePromise();
-      expect(overlayWrapper.getBoundingClientRect().bottom).toBe(
+      expect(overlayWrapper.getBoundingClientRect().bottom).toBeNear(
         clientTopForLine(component, 4)
       );
 
       // Does not flip the overlay vertically if it would overflow the top of the window
       overlayElement.style.height = 80 + 'px';
       await overlayComponent.getNextUpdatePromise();
-      expect(overlayWrapper.getBoundingClientRect().top).toBe(
+      expect(overlayWrapper.getBoundingClientRect().top).toBeNear(
         clientTopForLine(component, 5)
       );
 
@@ -2721,7 +2730,7 @@ describe('TextEditorComponent', () => {
       const { scrollContainer, gutterContainer } = component.refs;
 
       function checkScrollContainerLeft() {
-        expect(scrollContainer.getBoundingClientRect().left).toBe(
+        expect(scrollContainer.getBoundingClientRect().left).toBeNear(
           Math.round(gutterContainer.element.getBoundingClientRect().right)
         );
       }
@@ -2829,19 +2838,19 @@ describe('TextEditorComponent', () => {
       const [decorationNode3] = gutterB.getElement().firstChild.children;
 
       expect(decorationNode1.className).toBe('decoration a');
-      expect(decorationNode1.getBoundingClientRect().top).toBe(
+      expect(decorationNode1.getBoundingClientRect().top).toBeNear(
         clientTopForLine(component, 2)
       );
-      expect(decorationNode1.getBoundingClientRect().bottom).toBe(
+      expect(decorationNode1.getBoundingClientRect().bottom).toBeNear(
         clientTopForLine(component, 5)
       );
       expect(decorationNode1.firstChild).toBeNull();
 
       expect(decorationNode2.className).toBe('decoration b');
-      expect(decorationNode2.getBoundingClientRect().top).toBe(
+      expect(decorationNode2.getBoundingClientRect().top).toBeNear(
         clientTopForLine(component, 6)
       );
-      expect(decorationNode2.getBoundingClientRect().bottom).toBe(
+      expect(decorationNode2.getBoundingClientRect().bottom).toBeNear(
         clientTopForLine(component, 8)
       );
       expect(decorationNode2.firstChild).toBe(decorationElement1);
@@ -2851,10 +2860,10 @@ describe('TextEditorComponent', () => {
       expect(decorationElement1.offsetWidth).toBe(decorationNode2.offsetWidth);
 
       expect(decorationNode3.className).toBe('decoration');
-      expect(decorationNode3.getBoundingClientRect().top).toBe(
+      expect(decorationNode3.getBoundingClientRect().top).toBeNear(
         clientTopForLine(component, 9)
       );
-      expect(decorationNode3.getBoundingClientRect().bottom).toBe(
+      expect(decorationNode3.getBoundingClientRect().bottom).toBeNear(
         clientTopForLine(component, 12) + component.getLineHeight()
       );
       expect(decorationNode3.firstChild).toBe(decorationElement2);
@@ -2992,7 +3001,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item1) +
           getElementHeight(item2)
@@ -3039,7 +3048,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item1) +
           getElementHeight(item2) +
@@ -3078,7 +3087,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3113,7 +3122,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3147,7 +3156,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3183,7 +3192,7 @@ describe('TextEditorComponent', () => {
       );
       expect(component.getRenderedStartRow()).toBe(3);
       expect(component.getRenderedEndRow()).toBe(12);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3214,7 +3223,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3253,7 +3262,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3303,7 +3312,7 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise();
       expect(component.getRenderedStartRow()).toBe(0);
       expect(component.getRenderedEndRow()).toBe(9);
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3341,7 +3350,7 @@ describe('TextEditorComponent', () => {
           component.getRenderedStartRow() === 0 &&
           component.getRenderedEndRow() === 13
       );
-      expect(component.getScrollHeight()).toBe(
+      expect(component.getScrollHeight()).toBeNear(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +
           getElementHeight(item3) +
@@ -3832,16 +3841,16 @@ describe('TextEditorComponent', () => {
           tile.tileStartRow
         ).parentElement;
         const linesTileBoundingRect = linesTileElement.getBoundingClientRect();
-        expect(linesTileBoundingRect.height).toBe(tile.height);
-        expect(linesTileBoundingRect.top).toBe(top);
+        expect(linesTileBoundingRect.height).toBeNear(tile.height);
+        expect(linesTileBoundingRect.top).toBeNear(top);
 
         const lineNumbersTileElement = lineNumberNodeForScreenRow(
           component,
           tile.tileStartRow
         ).parentElement;
         const lineNumbersTileBoundingRect = lineNumbersTileElement.getBoundingClientRect();
-        expect(lineNumbersTileBoundingRect.height).toBe(tile.height);
-        expect(lineNumbersTileBoundingRect.top).toBe(top);
+        expect(lineNumbersTileBoundingRect.height).toBeNear(tile.height);
+        expect(lineNumbersTileBoundingRect.top).toBeNear(top);
 
         top += tile.height;
       }
@@ -3853,7 +3862,7 @@ describe('TextEditorComponent', () => {
       for (let row = startRow; row < endRow; row++) {
         const lineNode = lineNodeForScreenRow(component, row);
         const lineNumberNode = lineNumberNodeForScreenRow(component, row);
-        expect(lineNumberNode.getBoundingClientRect().top).toBe(
+        expect(lineNumberNode.getBoundingClientRect().top).toBeNear(
           lineNode.getBoundingClientRect().top
         );
       }
@@ -3986,8 +3995,8 @@ describe('TextEditorComponent', () => {
       element.style.height = 4 * component.getLineHeight() + 'px';
       await component.getNextUpdatePromise();
       await setScrollTop(component, 4 * component.getLineHeight());
-      expect(component.getRenderedStartRow()).toBe(4);
-      expect(component.getRenderedEndRow()).toBe(9);
+      expect(component.getRenderedStartRow()).toBeNear(4);
+      expect(component.getRenderedEndRow()).toBeNear(9);
 
       const markerLayer = editor.addMarkerLayer();
       const marker1 = markerLayer.markBufferRange([[0, 0], [4, 5]]);
@@ -4780,8 +4789,8 @@ describe('TextEditorComponent', () => {
           didDrag({ clientX: 199, clientY: 199 });
           didDrag({ clientX: 199, clientY: 199 });
           didDrag({ clientX: 199, clientY: 199 });
-          expect(component.getScrollTop()).toBe(maxScrollTop);
-          expect(component.getScrollLeft()).toBe(maxScrollLeft);
+          expect(component.getScrollTop()).toBeNear(maxScrollTop);
+          expect(component.getScrollLeft()).toBeNear(maxScrollLeft);
         });
       });
 
@@ -5137,8 +5146,8 @@ describe('TextEditorComponent', () => {
         didDrag({ clientX: 199, clientY: 199 });
         didDrag({ clientX: 199, clientY: 199 });
         didDrag({ clientX: 199, clientY: 199 });
-        expect(component.getScrollTop()).toBe(maxScrollTop);
-        expect(component.getScrollLeft()).toBe(maxScrollLeft);
+        expect(component.getScrollTop()).toBeNear(maxScrollTop);
+        expect(component.getScrollLeft()).toBeNear(maxScrollLeft);
       });
     });
 
@@ -5758,7 +5767,7 @@ describe('TextEditorComponent', () => {
           row: 12,
           column: 1
         });
-        expect(top).toBe(
+        expect(top).toBeNear(
           clientTopForLine(referenceComponent, 12) - referenceContentRect.top
         );
         expect(left).toBeNear(
@@ -5775,7 +5784,7 @@ describe('TextEditorComponent', () => {
           row: 3,
           column: 5
         });
-        expect(top).toBe(
+        expect(top).toBeNear(
           clientTopForLine(referenceComponent, 3) - referenceContentRect.top
         );
         expect(left).toBeNear(
@@ -5956,7 +5965,9 @@ describe('TextEditorComponent', () => {
         'px';
       await component.getNextUpdatePromise();
 
-      expect(component.getMaxScrollTop() / component.getLineHeight()).toBe(9);
+      expect(component.getMaxScrollTop() / component.getLineHeight()).toBeNear(
+        9
+      );
       expect(component.refs.verticalScrollbar.element.scrollTop).toBe(
         0 * component.getLineHeight()
       );
@@ -5964,21 +5975,21 @@ describe('TextEditorComponent', () => {
       editor.setFirstVisibleScreenRow(1);
       expect(component.getFirstVisibleRow()).toBe(1);
       await component.getNextUpdatePromise();
-      expect(component.refs.verticalScrollbar.element.scrollTop).toBe(
+      expect(component.refs.verticalScrollbar.element.scrollTop).toBeNear(
         1 * component.getLineHeight()
       );
 
       editor.setFirstVisibleScreenRow(5);
       expect(component.getFirstVisibleRow()).toBe(5);
       await component.getNextUpdatePromise();
-      expect(component.refs.verticalScrollbar.element.scrollTop).toBe(
+      expect(component.refs.verticalScrollbar.element.scrollTop).toBeNear(
         5 * component.getLineHeight()
       );
 
       editor.setFirstVisibleScreenRow(11);
       expect(component.getFirstVisibleRow()).toBe(9);
       await component.getNextUpdatePromise();
-      expect(component.refs.verticalScrollbar.element.scrollTop).toBe(
+      expect(component.refs.verticalScrollbar.element.scrollTop).toBeNear(
         9 * component.getLineHeight()
       );
     });
@@ -6184,7 +6195,7 @@ async function setEditorWidthInCharacters(component, widthInCharacters) {
 
 function verifyCursorPosition(component, cursorNode, row, column) {
   const rect = cursorNode.getBoundingClientRect();
-  expect(Math.round(rect.top)).toBe(clientTopForLine(component, row));
+  expect(Math.round(rect.top)).toBeNear(clientTopForLine(component, row));
   expect(Math.round(rect.left)).toBe(
     Math.round(clientLeftForCharacter(component, row, column))
   );

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -723,7 +723,7 @@ describe('TextEditorComponent', () => {
       expect(hiddenInput.getBoundingClientRect().top).toBe(
         clientTopForLine(component, 7)
       );
-      expect(Math.round(hiddenInput.getBoundingClientRect().left)).toBe(
+      expect(Math.round(hiddenInput.getBoundingClientRect().left)).toBeNear(
         clientLeftForCharacter(component, 7, 4)
       );
     });
@@ -1483,7 +1483,7 @@ describe('TextEditorComponent', () => {
         lineNodeForScreenRow(component, 1).getBoundingClientRect().left -
         editor.horizontalScrollMargin *
           component.measurements.baseCharacterWidth;
-      expect(component.getScrollLeft()).toBeCloseTo(expectedScrollLeft, 0);
+      expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
 
       editor.scrollToScreenRange([[1, 12], [2, 28]], { reversed: false });
       await component.getNextUpdatePromise();
@@ -1494,7 +1494,7 @@ describe('TextEditorComponent', () => {
         editor.horizontalScrollMargin *
           component.measurements.baseCharacterWidth -
         component.getScrollContainerClientWidth();
-      expect(component.getScrollLeft()).toBeCloseTo(expectedScrollLeft, 0);
+      expect(component.getScrollLeft()).toBeNear(expectedScrollLeft);
     });
 
     it('does not horizontally autoscroll by more than half of the visible "base-width" characters if the editor is narrower than twice the scroll margin', async () => {
@@ -2247,10 +2247,10 @@ describe('TextEditorComponent', () => {
         expect(regionRect.top).toBe(
           lineNodeForScreenRow(component, 1).getBoundingClientRect().top
         );
-        expect(Math.round(regionRect.left)).toBe(
+        expect(Math.round(regionRect.left)).toBeNear(
           clientLeftForCharacter(component, 1, 2)
         );
-        expect(Math.round(regionRect.right)).toBe(
+        expect(Math.round(regionRect.right)).toBeNear(
           clientLeftForCharacter(component, 1, 10)
         );
       }
@@ -2268,10 +2268,10 @@ describe('TextEditorComponent', () => {
         expect(regionRect.bottom).toBe(
           lineNodeForScreenRow(component, 1).getBoundingClientRect().bottom
         );
-        expect(Math.round(regionRect.left)).toBe(
+        expect(Math.round(regionRect.left)).toBeNear(
           clientLeftForCharacter(component, 1, 4)
         );
-        expect(Math.round(regionRect.right)).toBe(
+        expect(Math.round(regionRect.right)).toBeNear(
           clientLeftForCharacter(component, 1, 8)
         );
       }
@@ -2296,10 +2296,10 @@ describe('TextEditorComponent', () => {
         expect(region0Rect.bottom).toBe(
           lineNodeForScreenRow(component, 2).getBoundingClientRect().bottom
         );
-        expect(Math.round(region0Rect.left)).toBe(
+        expect(Math.round(region0Rect.left)).toBeNear(
           clientLeftForCharacter(component, 2, 4)
         );
-        expect(Math.round(region0Rect.right)).toBe(
+        expect(Math.round(region0Rect.right)).toBeNear(
           component.refs.content.getBoundingClientRect().right
         );
 
@@ -2310,10 +2310,10 @@ describe('TextEditorComponent', () => {
         expect(region1Rect.bottom).toBe(
           lineNodeForScreenRow(component, 3).getBoundingClientRect().bottom
         );
-        expect(Math.round(region1Rect.left)).toBe(
+        expect(Math.round(region1Rect.left)).toBeNear(
           clientLeftForCharacter(component, 3, 0)
         );
-        expect(Math.round(region1Rect.right)).toBe(
+        expect(Math.round(region1Rect.right)).toBeNear(
           clientLeftForCharacter(component, 3, 4)
         );
       }
@@ -2334,10 +2334,10 @@ describe('TextEditorComponent', () => {
         expect(region0Rect.bottom).toBe(
           lineNodeForScreenRow(component, 2).getBoundingClientRect().bottom
         );
-        expect(Math.round(region0Rect.left)).toBe(
+        expect(Math.round(region0Rect.left)).toBeNear(
           clientLeftForCharacter(component, 2, 4)
         );
-        expect(Math.round(region0Rect.right)).toBe(
+        expect(Math.round(region0Rect.right)).toBeNear(
           component.refs.content.getBoundingClientRect().right
         );
 
@@ -2365,7 +2365,7 @@ describe('TextEditorComponent', () => {
         expect(Math.round(region2Rect.left)).toBe(
           component.refs.content.getBoundingClientRect().left
         );
-        expect(Math.round(region2Rect.right)).toBe(
+        expect(Math.round(region2Rect.right)).toBeNear(
           clientLeftForCharacter(component, 5, 4)
         );
       }
@@ -2599,13 +2599,13 @@ describe('TextEditorComponent', () => {
       expect(overlayWrapper.getBoundingClientRect().top).toBe(
         clientTopForLine(component, 5)
       );
-      expect(overlayWrapper.getBoundingClientRect().left).toBe(
+      expect(overlayWrapper.getBoundingClientRect().left).toBeNear(
         clientLeftForCharacter(component, 4, 25)
       );
 
       // Updates the horizontal position on scroll
       await setScrollLeft(component, 150);
-      expect(overlayWrapper.getBoundingClientRect().left).toBe(
+      expect(overlayWrapper.getBoundingClientRect().left).toBeNear(
         clientLeftForCharacter(component, 4, 25)
       );
 
@@ -5747,7 +5747,7 @@ describe('TextEditorComponent', () => {
         expect(top).toBe(
           clientTopForLine(referenceComponent, 0) - referenceContentRect.top
         );
-        expect(left).toBe(
+        expect(left).toBeNear(
           clientLeftForCharacter(referenceComponent, 0, 5) -
             referenceContentRect.left
         );
@@ -5761,7 +5761,7 @@ describe('TextEditorComponent', () => {
         expect(top).toBe(
           clientTopForLine(referenceComponent, 12) - referenceContentRect.top
         );
-        expect(left).toBe(
+        expect(left).toBeNear(
           clientLeftForCharacter(referenceComponent, 12, 1) -
             referenceContentRect.left
         );
@@ -5778,7 +5778,7 @@ describe('TextEditorComponent', () => {
         expect(top).toBe(
           clientTopForLine(referenceComponent, 3) - referenceContentRect.top
         );
-        expect(left).toBe(
+        expect(left).toBeNear(
           clientLeftForCharacter(referenceComponent, 3, 5) -
             referenceContentRect.left
         );

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -486,10 +486,10 @@ describe('TextEditorComponent', () => {
 
         expect(getHorizontalScrollbarHeight(component)).toBeNear(10);
         expect(getVerticalScrollbarWidth(component)).toBeNear(10);
-        expect(component.refs.horizontalScrollbar.element.style.right).toBe(
+        expect(component.refs.horizontalScrollbar.element.style.right).toHaveNearPixels(
           '10px'
         );
-        expect(component.refs.verticalScrollbar.element.style.bottom).toBe(
+        expect(component.refs.verticalScrollbar.element.style.bottom).toHaveNearPixels(
           '10px'
         );
         expect(component.refs.horizontalScrollbar.element.scrollLeft).toBeNear(
@@ -507,10 +507,10 @@ describe('TextEditorComponent', () => {
 
         expect(getHorizontalScrollbarHeight(component)).toBeNear(10);
         expect(getVerticalScrollbarWidth(component)).toBeNear(10);
-        expect(component.refs.horizontalScrollbar.element.style.right).toBe(
+        expect(component.refs.horizontalScrollbar.element.style.right).toHaveNearPixels(
           '10px'
         );
-        expect(component.refs.verticalScrollbar.element.style.bottom).toBe(
+        expect(component.refs.verticalScrollbar.element.style.bottom).toHaveNearPixels(
           '10px'
         );
         expect(component.refs.horizontalScrollbar.element.scrollLeft).toBeNear(


### PR DESCRIPTION
### Description of the change

For #21777 

This adds a toBeNear jasmine helper, which allows setting an accepted error for the comparison of the two numbers. This is used in text-editor-component-spec to fix the test errors that have an only a slight acceptable error (less than 1 pixel). These errors are because the newer browser engines optimize the position and style calculations (which makes them have an acceptable error).

It also adds toHaveNearPixels that uses a combination of indexOf and parseInt to compare pixel strings using toBeNear logic

Running the tests locally has a lot of these!! But in the CI, they seem to be less.

### Verification

The running CI: https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=1044&view=results

Examples:
```
    it TextEditorComponent autoscroll automatically scrolls horizontally when the requested range is within the horizontal scroll margin of the right edge of the gutter or right edge of the scroll container
      Expected 39 to be close to 39.515625, 0.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:1486:41)
      Expected 157 to be close to 156.390625, 0.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:1497:41)
  highlight decorations
    it TextEditorComponent highlight decorations renders single-line highlights
      Expected 49 to be 49.203125.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2250:45)
      Expected 102 to be 101.984375.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2253:46)
      Expected 62 to be 62.390625.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2271:45)
      Expected 89 to be 88.78125.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2274:46)
    it TextEditorComponent highlight decorations renders multi-line highlights
      Expected 62 to be 62.390625.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2299:46)
      Expected 62 to be 62.390625.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2316:47)
      Expected 62 to be 62.390625.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2337:46)
      Expected 62 to be 62.390625.
        at jasmine.Spec.<anonymous> (D:\a\1\s\spec\text-editor-component-spec.js:2368:47)
  overlay decorations
    it TextEditorComponent overlay decorations renders overlay elements at the specified screen position unless it would overflow the window
      Expected 121 to be 120.9375.

```

