### PR TITLE
Add GitHub action to detect spam PRs

### DIFF
--- a/.github/workflows/spam_pr_checker.yml
+++ b/.github/workflows/spam_pr_checker.yml
@@ -1,0 +1,25 @@
+name: Pull Request spam checker
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  SpamCheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check Pull Request comments
+        uses: atom-ide-community/check-pr-comments-action@v0.0.3
+        with:
+          comments-must-contain: '### Description'
+          comments-must-not-contain: 'Hello there! Welcome. Please follow the steps below to tell us about your contribution'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Spamtoberfest
+        uses: atom-ide-community/spamtoberfest@v1.1
+        with:
+          action-type: close
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spam_pr_checker.yml
+++ b/.github/workflows/spam_pr_checker.yml
@@ -10,13 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check Pull Request comments
-        uses: atom-ide-community/check-pr-comments-action@v0.0.3
-        with:
-          comments-must-contain: '### Description'
-          comments-must-not-contain: 'Hello there! Welcome. Please follow the steps below to tell us about your contribution'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Check Pull Request comments
+      #   uses: atom-ide-community/check-pr-comments-action@v0.0.3
+      #   with:
+      #     comments-must-contain: '### Description'
+      #     comments-must-not-contain: 'Hello there! Welcome. Please follow the steps below to tell us about your contribution'
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Spamtoberfest
         uses: atom-ide-community/spamtoberfest@v1.1


### PR DESCRIPTION
### Description of the change

This PR adds a GitHub Action to detect and close the spam PRs. It is done by ~~checking the PR's comment~~ and also checking against Spamtoberfest's database.

### Benefits

- No more spam PRs will be allowed. Some example of such pull requests in the recent months:

#22107 #21828 #21824 #21808 #21747 #21723 #21775 #21612 #21607 #21606 #21580 #21350 #21471 #21523 #21489 #21486 #21312 #21306 #21301

- This also allows growing Spamtoberfest database by adding the users that make such invalid pull requests. 

~~- Encourages the contributors to follow the PR templates. At minimum `### Description` should be included. This is only effective for the newly opened pull requests.~~

- No risk is involved in using this action because the used GitHub actions are hosted and locked at @atom-ide-community:
https://github.com/atom-ide-community/check-pr-comments-action
https://github.com/atom-ide-community/spamtoberfest

### Drawbacks
None

### Verification
The actions will run once a new PR is opened. 

### Release Notes
N/A