### PR TITLE
Fix Atom not quitting on MacOS

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -1107,19 +1107,11 @@ describe('AtomApplication', function() {
   });
 
   describe('when closing the last window', function() {
-    if (process.platform === 'linux' || process.platform === 'win32') {
-      it('quits the application', async function() {
-        const [w] = await scenario.launch(parseCommandLine(['a']));
-        scenario.getApplication(0).removeWindow(w);
-        assert.isTrue(electron.app.quit.called);
-      });
-    } else if (process.platform === 'darwin') {
-      it('leaves the application open', async function() {
-        const [w] = await scenario.launch(parseCommandLine(['a']));
-        scenario.getApplication(0).removeWindow(w);
-        assert.isFalse(electron.app.quit.called);
-      });
-    }
+    it('quits the application', async function() {
+      const [w] = await scenario.launch(parseCommandLine(['a']));
+      scenario.getApplication(0).removeWindow(w);
+      assert.isTrue(electron.app.quit.called);
+    });
   });
 
   describe('quitting', function() {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -458,10 +458,8 @@ module.exports = class AtomApplication extends EventEmitter {
       if (this.applicationMenu != null) {
         this.applicationMenu.enableWindowSpecificItems(false);
       }
-      if (['win32', 'linux'].includes(process.platform)) {
-        app.quit();
-        return;
-      }
+      app.quit();
+      return;
     }
     if (!window.isSpec) this.saveCurrentWindowOptions(true);
   }


### PR DESCRIPTION
### Description of the change

This makes Atom quitting on MacOS like any other operating system.

### Applicable issues
Fixes the critical issues that have been open for a long time:
Fixes #17672
Fixes #20831

### Verification

Atom will be closed like macOS and Linux. So, there will not be any behavior difference causing errors like #17672

The Official CI's download links for the PR's build
https://github.visualstudio.com/Atom/_build/results?buildId=94291&view=artifacts&type=publishedArtifacts

### Release Notes
- Fix Atom not quitting on MacOS in some cases
