### PR TITLE
🍎 Don't quit upon 'window-all-closed' event on macOS

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -455,8 +455,7 @@ module.exports = class AtomApplication extends EventEmitter {
   removeWindow(window) {
     this.windowStack.removeWindow(window);
     if (this.getAllWindows().length === 0 && process.platform !== 'darwin') {
-      // We should be quitting now in the 'window-all-closed' event handler.
-      // We can skip anything past this point in removeWindow().
+      app.quit();
       return;
     }
     if (!window.isSpec) this.saveCurrentWindowOptions(true);

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -768,13 +768,13 @@ module.exports = class AtomApplication extends EventEmitter {
       })
     );
 
-    // Don't quit when the last window is closed on macOS. Overrides the default Electron behavior.
-    // See: https://github.com/electron/electron/blob/v11.1.1/docs/api/app.md#event-window-all-closed
+    // See: https://www.electronjs.org/docs/api/app#event-window-all-closed
     this.disposable.add(
       ipcHelpers.on(app, 'window-all-closed', () => {
         if (this.applicationMenu != null) {
           this.applicationMenu.enableWindowSpecificItems(false);
         }
+        // Don't quit when the last window is closed on macOS.
         if (process.platform !== 'darwin') {
           app.quit();
         }

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -773,6 +773,16 @@ module.exports = class AtomApplication extends EventEmitter {
       })
     );
 
+    // Don't quit when the last window is closed on macOS. Overrides the default Electron behavior.
+    // See: https://github.com/electron/electron/blob/v11.1.1/docs/api/app.md#event-window-all-closed
+    this.disposable.add(
+      ipcHelpers.on(app, 'window-all-closed', () => {
+        if (process.platform !== 'darwin') {
+          app.quit();
+        }
+      })
+    );
+
     // Triggered by the 'open-file' event from Electron:
     // https://electronjs.org/docs/api/app#event-open-file-macos
     // For example, this is fired when a file is dragged and dropped onto the Atom application icon in the dock.

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -454,14 +454,10 @@ module.exports = class AtomApplication extends EventEmitter {
   // Public: Removes the {AtomWindow} from the global window list.
   removeWindow(window) {
     this.windowStack.removeWindow(window);
-    if (this.getAllWindows().length === 0) {
-      if (this.applicationMenu != null) {
-        this.applicationMenu.enableWindowSpecificItems(false);
-      }
-      if (['win32', 'linux'].includes(process.platform)) {
-        app.quit();
-        return;
-      }
+    if (this.getAllWindows().length === 0 && process.platform !== 'darwin') {
+      // We should be quitting now in the 'window-all-closed' event handler.
+      // We can skip anything past this point in removeWindow().
+      return;
     }
     if (!window.isSpec) this.saveCurrentWindowOptions(true);
   }
@@ -777,6 +773,9 @@ module.exports = class AtomApplication extends EventEmitter {
     // See: https://github.com/electron/electron/blob/v11.1.1/docs/api/app.md#event-window-all-closed
     this.disposable.add(
       ipcHelpers.on(app, 'window-all-closed', () => {
+        if (this.applicationMenu != null) {
+          this.applicationMenu.enableWindowSpecificItems(false);
+        }
         if (process.platform !== 'darwin') {
           app.quit();
         }

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -104,14 +104,6 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
     })
   );
 
-  // Don't quit when the last window is closed on macOS. Overrides the default Electron behavior.
-  // See: https://github.com/electron/electron/blob/v11.1.1/docs/api/app.md#event-window-all-closed
-  app.on('window-all-closed', () => {
-    if (process.platform !== 'darwin') {
-      app.quit();
-    }
-  });
-
   if (args.userDataDir != null) {
     app.setPath('userData', args.userDataDir);
   } else if (args.test || args.benchmark || args.benchmarkTest) {

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -104,6 +104,14 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
     })
   );
 
+  // Don't quit when the last window is closed on macOS. Overrides the default Electron behavior.
+  // See: https://github.com/electron/electron/blob/v11.1.1/docs/api/app.md#event-window-all-closed
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+      app.quit();
+    }
+  });
+
   if (args.userDataDir != null) {
     app.setPath('userData', args.userDataDir);
   } else if (args.test || args.benchmark || args.benchmarkTest) {


### PR DESCRIPTION
This prevents a lot of buggy partial-quitting stuff from happening.


<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Fixes: https://github.com/atom/atom/issues/17672
Fixes: https://github.com/atom/atom/issues/20831

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In order to avoid a buggy, "half-quit" state, don't attempt to quit on macOS when the last window is closed.

More technically: listen for and handle the `'window-all-closed'` event in a custom way, overriding the default behavior Electron provides. ([Electron's default behavior for this event simply calls `app.quit()`, regardless of OS.](https://github.com/electron/electron/blob/v11.1.1/lib/browser/init.ts#L193-L198) We can do essentially the same, but conditionally not quit if the OS is `'darwin'` meaning macOS.)

_[`'window-all-closed'` event documentation at electronjs.org](https://github.com/electron/electron/blob/v11.1.1/docs/api/app.md#event-window-all-closed)_

In this way, we can allow Atom to stay running in the background ready to open new windows quickly, as it is intended to.

_(For reasons that aren't entirely clear to me, Atom's code has been partly preventing this quitting, but still setting an `atomApplication.quitting` variable to `true`, which later on causes some buggy behavior around quitting and closing windows. This pull request addresses and prevents the bugginess.)_

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Remove the "Atom process in the background" feature altogether, to avoid these bugs: #21843
  - Having Atom run in the background, ready to open new windows quickly, is a desirable feature. So we should fix the underlying issue rather than disable the feature.
- Introduce some way of force quitting from within the app, that is call [`app.exit()`](https://github.com/electron/electron/blob/v11.1.1/docs/api/app.md#appexitexitcode)?
  - Not necessary now that Atom behaves itself and quits properly when asked to. Most of the time. 😛

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I built Atom locally with this change. I confirmed that the steps to reproduce identified in https://github.com/atom/atom/issues/17672#issuecomment-753424712 are no-longer reproducible.

CI passes.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fix buggy quitting behavior on macOS after all windows are closed