### PR TITLE
Fix buggy partial startup on macOS due to flag added by Gatekeeper/XProtect

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -724,7 +724,7 @@ describe('AtomApplication', function() {
     });
 
     it('opens a file to a specific line number and column', async function() {
-      await scenario.open(parseCommandLine('b/2.md:12:5'));
+      await scenario.open(parseCommandLine(['b/2.md:12:5']));
       await scenario.assert('[_ 2.md]');
 
       const w = scenario.getWindow(0);
@@ -750,7 +750,7 @@ describe('AtomApplication', function() {
     });
 
     it('truncates trailing whitespace and colons', async function() {
-      await scenario.open(parseCommandLine('b/2.md::  '));
+      await scenario.open(parseCommandLine(['b/2.md::  ']));
       await scenario.assert('[_ 2.md]');
 
       const w = scenario.getWindow(0);

--- a/spec/main-process/parse-command-line.test.js
+++ b/spec/main-process/parse-command-line.test.js
@@ -41,4 +41,27 @@ describe('parseCommandLine', () => {
       assert.deepEqual(args.pathsToOpen, []);
     });
   });
+
+  describe('when evil macOS Gatekeeper flag "-psn_0_[six or seven digits here]" is passed', () => {
+    it('ignores any arguments starting with "-psn_"', () => {
+      const getPsnFlag = () => { return `-psn_0_${Math.floor(Math.random() * 10_000_000)}` };
+      const args = parseCommandLine([
+        getPsnFlag(),
+        '/some/path',
+        getPsnFlag(),
+        getPsnFlag(),
+        'some/other/path',
+        'atom://test/url',
+        getPsnFlag(),
+        'atom://other/url',
+        '-psn_ Any argument starting with "-psn_" should be ignored, even this one.',
+        './another-path.file'
+      ]);
+      assert.deepEqual(args.urlsToOpen, [
+        'atom://test/url',
+        'atom://other/url'
+      ]);
+      assert.deepEqual(args.pathsToOpen, ['/some/path', 'some/other/path', './another-path.file']);
+    });
+  });
 });

--- a/spec/main-process/parse-command-line.test.js
+++ b/spec/main-process/parse-command-line.test.js
@@ -24,7 +24,6 @@ describe('parseCommandLine', () => {
 
     describe('and --_ or -_ are passed', () => {
       it('does not attempt to parse booleans as paths or URIs', () => {
-        const getPsnFlag = () => { return `-psn_0_${Math.floor(Math.random() * 10_000_000)}` };
         const args = parseCommandLine([
           '--_',
           '/some/path',
@@ -44,13 +43,16 @@ describe('parseCommandLine', () => {
           'atom://test/url',
           'atom://other/url'
         ]);
-        assert.deepEqual(args.pathsToOpen, ['/some/path', 'some/other/path', './another-path.file']);
+        assert.deepEqual(args.pathsToOpen, [
+          '/some/path',
+          'some/other/path',
+          './another-path.file'
+        ]);
       });
     });
 
     describe('and a non-flag number is passed as an argument', () => {
       it('does not attempt to parse numbers as paths or URIs', () => {
-        const getPsnFlag = () => { return `-psn_0_${Math.floor(Math.random() * 10_000_000)}` };
         const args = parseCommandLine([
           '43',
           '/some/path',
@@ -67,7 +69,11 @@ describe('parseCommandLine', () => {
           'atom://test/url',
           'atom://other/url'
         ]);
-        assert.deepEqual(args.pathsToOpen, ['/some/path', 'some/other/path', './another-path.file']);
+        assert.deepEqual(args.pathsToOpen, [
+          '/some/path',
+          'some/other/path',
+          './another-path.file'
+        ]);
       });
     });
   });
@@ -93,7 +99,9 @@ describe('parseCommandLine', () => {
 
   describe('when evil macOS Gatekeeper flag "-psn_0_[six or seven digits here]" is passed', () => {
     it('ignores any arguments starting with "-psn_"', () => {
-      const getPsnFlag = () => { return `-psn_0_${Math.floor(Math.random() * 10_000_000)}` };
+      const getPsnFlag = () => {
+        return `-psn_0_${Math.floor(Math.random() * 10_000_000)}`;
+      };
       const args = parseCommandLine([
         getPsnFlag(),
         '/some/path',
@@ -110,7 +118,11 @@ describe('parseCommandLine', () => {
         'atom://test/url',
         'atom://other/url'
       ]);
-      assert.deepEqual(args.pathsToOpen, ['/some/path', 'some/other/path', './another-path.file']);
+      assert.deepEqual(args.pathsToOpen, [
+        '/some/path',
+        'some/other/path',
+        './another-path.file'
+      ]);
     });
   });
 });

--- a/spec/main-process/parse-command-line.test.js
+++ b/spec/main-process/parse-command-line.test.js
@@ -22,6 +22,10 @@ describe('parseCommandLine', () => {
       assert.deepEqual(args.pathsToOpen, ['/some/path']);
     });
 
+    // The "underscore flag" with no "non-flag argument" after it
+    // is the minimal reproducer for the macOS Gatekeeper startup bug.
+    // By default, it causes the addition of boolean "true"s into yargs' "non-flag argument" array: `argv._`
+    // Whereas we do string-only operations on these arguments, expecting them to be paths or URIs.
     describe('and --_ or -_ are passed', () => {
       it('does not attempt to parse booleans as paths or URIs', () => {
         const args = parseCommandLine([

--- a/spec/main-process/parse-command-line.test.js
+++ b/spec/main-process/parse-command-line.test.js
@@ -21,6 +21,55 @@ describe('parseCommandLine', () => {
       ]);
       assert.deepEqual(args.pathsToOpen, ['/some/path']);
     });
+
+    describe('and --_ or -_ are passed', () => {
+      it('does not attempt to parse booleans as paths or URIs', () => {
+        const getPsnFlag = () => { return `-psn_0_${Math.floor(Math.random() * 10_000_000)}` };
+        const args = parseCommandLine([
+          '--_',
+          '/some/path',
+          '-_',
+          '-_',
+          'some/other/path',
+          'atom://test/url',
+          '--_',
+          'atom://other/url',
+          '-_',
+          './another-path.file',
+          '-_',
+          '-_',
+          '-_'
+        ]);
+        assert.deepEqual(args.urlsToOpen, [
+          'atom://test/url',
+          'atom://other/url'
+        ]);
+        assert.deepEqual(args.pathsToOpen, ['/some/path', 'some/other/path', './another-path.file']);
+      });
+    });
+
+    describe('and a non-flag number is passed as an argument', () => {
+      it('does not attempt to parse numbers as paths or URIs', () => {
+        const getPsnFlag = () => { return `-psn_0_${Math.floor(Math.random() * 10_000_000)}` };
+        const args = parseCommandLine([
+          '43',
+          '/some/path',
+          '22',
+          '97',
+          'some/other/path',
+          'atom://test/url',
+          '885',
+          'atom://other/url',
+          '42',
+          './another-path.file'
+        ]);
+        assert.deepEqual(args.urlsToOpen, [
+          'atom://test/url',
+          'atom://other/url'
+        ]);
+        assert.deepEqual(args.pathsToOpen, ['/some/path', 'some/other/path', './another-path.file']);
+      });
+    });
   });
 
   describe('when --uri-handler is passed', () => {

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -5,7 +5,13 @@ const yargs = require('yargs');
 const { app } = require('electron');
 
 module.exports = function parseCommandLine(processArgs) {
-  const options = yargs(processArgs).wrap(yargs.terminalWidth());
+  // macOS Gatekeeper adds a flag ("-psn_0_[six or seven digits here]") when it intercepts Atom launches.
+  // (This happens for fresh downloads, new installs, or first launches after upgrading).
+  // We don't need this flag, and yargs interprets it as many short flags. So, we filter it out.
+  const filteredArgs = processArgs
+    .filter(arg => !arg.startsWith('-psn_'));
+
+  const options = yargs(filteredArgs).wrap(yargs.terminalWidth());
   const version = app.getVersion();
   options.usage(
     dedent`Atom Editor v${version}

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -193,6 +193,11 @@ module.exports = function parseCommandLine(processArgs) {
   let devMode = args['dev'];
 
   for (const path of args._) {
+    if (typeof path !== 'string') {
+      // Sometimes non-strings (such as numbers or boolean true) get into args._
+      // In the next block, .startsWith() only works on strings. So, skip non-string arguments.
+      continue;
+    }
     if (path.startsWith('atom://')) {
       urlsToOpen.push(path);
     } else {

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -8,8 +8,7 @@ module.exports = function parseCommandLine(processArgs) {
   // macOS Gatekeeper adds a flag ("-psn_0_[six or seven digits here]") when it intercepts Atom launches.
   // (This happens for fresh downloads, new installs, or first launches after upgrading).
   // We don't need this flag, and yargs interprets it as many short flags. So, we filter it out.
-  const filteredArgs = processArgs
-    .filter(arg => !arg.startsWith('-psn_'));
+  const filteredArgs = processArgs.filter(arg => !arg.startsWith('-psn_'));
 
   const options = yargs(filteredArgs).wrap(yargs.terminalWidth());
   const version = app.getVersion();


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<details><summary>Deeper technical explanation (click to expand)</summary>

_(Paraphrased from: https://github.com/atom/atom/issues/21751#issuecomment-757617110)_

[This bug appears] related to Gatekeeper.

[This] bug happens [when you] are launching Atom and see Gatekeeper pop up with a loading bar and a message 'Verifying "Atom"', or something about "This was downloaded from the internet, are you sure you want to open this?". This bug happens when Gatekeeper [intervenes in] launching the app [but the user clicks though/the app is verified and launching continues].

I see a command-line flag `-psn_0_[some six or seven digits here]` (something like `-psn_0_1234567`) applied to the buggy Atom process, when inspecting using [`htop`](https://htop.dev) or `ps -ax`. I have seen reports elsewhere that this flag is added by Gatekeeper. For example: https://github.com/godotengine/godot/pull/37719

Our argument parser library `yargs` thinks this `-psn_0_1234567` flag is a bunch of short flags, equivalent to `-p`, `-s`, `-n`, `-_`, `-0`, `-_`, `-1`, `-2`, `-3`, `-4`, `-5`, `-6`, `-7`. The `-_` are converted to boolean `true`, and then we try to do JS string-only operations on the flags. Doing [`true.startsWith()`](https://github.com/atom/atom/blob/v1.53.0/src/main-process/parse-command-line.js#L190) results in a TypeError ("`path.startsWith` is not a function") very early in our initialization process, leaving the app barely started up at all, and unable to respond to most kinds of input other than quitting.

Quitting and restarting means Gatekeeper is already familiar with the binary, and it won't intervene with launching the app. So the flag doesn't get added, and Atom works fine after a restart.

</details>

Fixes: https://github.com/atom/atom/issues/21013 (probably)
Fixes: https://github.com/atom/atom/issues/21751
Fixes: https://github.com/atom/atom/issues/21820

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- Filter out a flag (`-psn_0_[1234567]`) that macOS Gatekeeper/XProtect adds to Atom. Filter it out before `yargs` tries to parse it.
  - More-precisely: Filter out any argument passed to Atom that starts with `-psn_`.
  - (This flag is bogus input for our purposes. `yargs` thinks this is many shortflags (`-p` `-s` `-n` `-_` `-0` `-_`...); Parsing and handling all of them without it causing trouble is somewhat difficult. Filtering it out early avoids all the complications and bugs (TypeErrors, partial startups).)
- Also, as a further step to avoid problems from potentially similar flags in the future, completely ignore non-string items in the `args._` array, in one of the functions that decides whether an argument is a path or a URI.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

We could use just one of these two fixes instead of both. I included both to be thorough and handle more potential situations more correctly.

<details><summary>Miscellaneous other proposals (click to expand):</summary>

 I also considered converting number arguments to strings, so users can easily open a file like `55` or `100` in the current directory (no file extension or relative/absolute path needed). But I left that out because it felt like it was veering off-topic for a bug-fix. (`yargs` has [an option](http://yargs.js.org/docs/#api-reference-stringkey) that supposedly would do that for us, but it doesn't help very much in my testing; we would still need to filter out the zero-length strings it converts boolean `true` to with that option, and we would still need to manually convert numbers to strings, because that part doesn't work. I think that's a bug in `yargs`.)

</details>

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

_(I expected tiny slowdowns, but the relevant tests run at the same ~16-18ms speed on this branch as `master` branch on my machine.)_

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Added tests to describe new expected behavior. Tests pass.

macOS Gatekeeper flag no-longer prevents Atom from completely starting up.

To reproduce the problem, run this in the Terminal app: `atom "-psn_0_1234567"`. You should see the partial startup bug as described in the issues (linked at the top of this PR).

Try again on this branch to confirm the bug goes away; For example, using Atom in dev mode:

```
cd atom
git remote add deedeeg https://github.com/DeeDeeG/atom
git remote update deedeeg
git switch bugfix-deal-with-macos-gatekeeper-flag
./out/Atom\ Dev.app/Contents/MacOS/Atom\ Dev --dev --resource-path=/Users/[you]/path/where/you/cloned/atom -psn_0_1234567
```

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fixed buggy partial startup on macOS due to flag added by Gatekeeper/XProtect