### PR TITLE
Revert  tree-sitter-rust@0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4861,17 +4861,7 @@
     "language-rust-bundled": {
       "version": "file:packages/language-rust-bundled",
       "requires": {
-        "tree-sitter-rust": "^0.17.0"
-      },
-      "dependencies": {
-        "tree-sitter-rust": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.17.0.tgz",
-          "integrity": "sha512-dWYKrX4JbuLbKagTeCSsMZuFDKTzzaEHECsjLzIqbO/IhNHHLOzEcbF2YcIAGKG5thiT/lnNAjeOXDsILteCpg==",
-          "requires": {
-            "nan": "^2.8.0"
-          }
-        }
+        "tree-sitter-rust": "^0.16.0"
       }
     },
     "language-sass": {
@@ -8304,6 +8294,14 @@
             "readable-stream": "^3.1.1"
           }
         }
+      }
+    },
+    "tree-sitter-rust": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.16.0.tgz",
+      "integrity": "sha512-XzB/kJqrEJ6w6WnOn8d49yyzlQ8NXZ9bHCmKtX0mUB71cDMk/POCxiA4zsGb7Tv1R/im3Y+QsiY7UT4bl1lPYw==",
+      "requires": {
+        "nan": "^2.8.0"
       }
     },
     "tree-sitter-typescript": {

--- a/packages/language-rust-bundled/package.json
+++ b/packages/language-rust-bundled/package.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/atom/atom",
   "license": "MIT",
   "dependencies": {
-    "tree-sitter-rust": "^0.17.0"
+    "tree-sitter-rust": "^0.16.0"
   },
   "engines": {
     "atom": ">=1.0.0 <2.0.0"


### PR DESCRIPTION
This reverts commit ea5dbdfb571595bb327318a1a4748fde82b1c9b7 due to failing tests in our production branch. We need to further investigate why the failures are happening. 

I am currently unable to reproduce the failures locally.