### PR TITLE
CI: Cache the packages/ directory (fixes broken `language-rust-bundled` test)

### DIFF
--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -23,4 +23,4 @@ steps:
       GITHUB_TOKEN: $(GITHUB_TOKEN)
       CI: true
       CI_PROVIDER: VSTS
-    condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'))
+    condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'), ne(variables['LocalPackagesRestored'], 'true'))

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -11,20 +11,27 @@ steps:
   - task: Cache@2
     displayName: Cache node_modules
     inputs:
-      key: 'npm_main | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm_main | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'node_modules'
       cacheHitVar: MainNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache script/node_modules
     inputs:
-      key: 'npm_script | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm_script | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'script/node_modules'
       cacheHitVar: ScriptNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache apm/node_modules
     inputs:
-      key: 'npm_apm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm_apm | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored
+
+  - task: Cache@2
+    displayName: Cache packages/
+    inputs:
+      key: 'npm_local_packages | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      path: 'packages'
+      cacheHitVar: LocalPackagesRestored


### PR DESCRIPTION
Ensures we do not miss restoring these packages' `node_modules` folders when running the test jobs.

<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Fixes an overlooked edge case pertaining to the `Cache@2` CI task upgrade (https://github.com/atom/atom/pull/21057).

See discussion in https://github.com/atom/atom/pull/21790.

Due to the way `npm` installs packages that are specified as local paths (`./some/path`), and how caching was set up in Atom's CI, it was possible for Atom's CI to miss (fail to cache and restore) some packages' sub-dependencies. This could cause their tests to fail.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In CI, start caching the `packages/` directory. This ensures that those packages' `node_modules` folders (the packages' dependencies) are always restored in the post-build jobs. This is particularly relevant for ensuring the test jobs will pass.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- We could simply work around this infrequent issue by carefully hoisting dependencies. For example, this commit would solve the recent issue for the `language-rust-bundled` package: https://github.com/DeeDeeG/atom/commit/ab7c3b5
  - That would be a temporary solution though, meaning we might run into the same (rather confusing and counter-intuitive) issue again some time in the future.

- As an implementation detail, we could more easily specify these caches if using the older Lighthouse/Microsoft DevLabs caching tool: https://marketplace.visualstudio.com/items?itemName=1ESLighthouseEng.PipelineArtifactCaching
  - But this requires all forks of Atom wishing to run CI to install that addon task. Using the official Cache@V2 task keeps us current and makes it easier to fork Atom with working CI.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Adds about four or five seconds to each CI job.

Also, there will be some "warnings" about caches changing in the `macOS Tests packages-2` job:

```
##[warning]The given cache key has changed in its resolved value between restore and save steps;
```

These warnings are expected and can be safely ignored, but they add noise to the CI runs. If I figure out exactly which files change (probably some test fixtures or temp test output?) I might be able to filter those out in the cache ID.

(As mentioned in "Alternative  Designs", these warnings could be avoided with the old Lighthouse/Microsoft DevLabs cache task, but that task is unofficial and not supported anymore.)

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Ran CI with "Enable system diagnostics" checked. The right files are now cached and restored, including the `packages/` folder. See: [CI link](https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1011&view=logs&j=e2cf4b02-5697-54ad-cf7c-fc2a840d53af&t=d73d4063-6db5-4fd1-b374-4eaf9127a1b8)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A
