### PR TITLE
Move GitHub tests to their own CI job (workaround for failing tests in github 0.36.5+)

### DIFF
--- a/script/test
+++ b/script/test
@@ -300,6 +300,12 @@ function getPackageTestSuites() {
       );
       if (!packagesToTest.includes(packageName)) continue;
     }
+    if (process.env.ATOM_PACKAGES_TO_SKIP) {
+      const packagesToSkip = process.env.ATOM_PACKAGES_TO_SKIP.split(',').map(
+        pkg => pkg.trim()
+      );
+      if (packagesToSkip.includes(packageName)) continue;
+    }
 
     const repositoryPackagePath = path.join(
       CONFIG.repositoryRootPath,

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -23,6 +23,7 @@ jobs:
       - Windows_tests
       - Linux
       - macOS_tests
+      - macOS_tests_github
 
     variables:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -58,6 +58,7 @@ jobs:
         packages-1:
           RunCoreTests: false
           RunPackageTests: 1
+          ATOM_PACKAGES_TO_SKIP: "github"
         packages-2:
           RunCoreTests: false
           RunPackageTests: 2
@@ -80,3 +81,6 @@ jobs:
             - atom-mac-symbols.zip
 
       - template: templates/test.yml
+
+  # Import "macOS_tests_github" job
+  - template: templates/macos-tests-github.yml

--- a/script/vsts/platforms/templates/macos-tests-github.yml
+++ b/script/vsts/platforms/templates/macos-tests-github.yml
@@ -1,0 +1,56 @@
+jobs:
+  - job: macOS_tests_github
+    displayName: macOS Tests github
+    dependsOn: macOS_build
+    timeoutInMinutes: 180
+    pool:
+      vmImage: macos-10.15
+    variables:
+      ATOM_RESOURCE_PATH: $(Build.SourcesDirectory)
+      CI: true
+      CI_PROVIDER: VSTS
+      MOCHA_TIMEOUT: 60000
+      UNTIL_TIMEOUT: 30000
+    steps:
+      - template: ./preparation.yml
+
+      - template: ./cache.yml
+        parameters:
+          OS: macos
+
+      # The artifact caching task does not work on forks, so we need to
+      # bootstrap again for pull requests coming from forked repositories.
+      - template: ./bootstrap.yml
+
+      - template: ./download-unzip.yml
+        parameters:
+          artifacts:
+            - atom-mac.zip
+            - atom-mac-symbols.zip
+
+      - pwsh: |
+          cd $(Build.SourcesDirectory)/node_modules/github
+          $(Build.SourcesDirectory)/apm/node_modules/.bin/apm install
+        displayName: Prepare test dependencies for package
+        condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+
+      - pwsh: |
+          echo "CI env var is set to: $env:CI"
+          echo "MOCHA_TIMOUT env var is set to: $env:MOCHA_TIMEOUT"
+          echo "UNTIL_TIMOUT env var is set to: $env:UNTIL_TIMEOUT"
+
+          # Run tests, retrying up to 6 times if any tests fail
+          for ( $timesTriedToTest = 1; $timesTriedToTest -le 6; $timesTriedToTest++ ) {
+            echo "##[Command]Running tests for the github package `(attempt number $($timesTriedToTest)`)"
+
+            # Run tests
+            $(Build.SourcesDirectory)/out/Atom*.app/Contents/MacOS/Atom* --resource-path $(Build.SourcesDirectory) --test $(Build.SourcesDirectory)/node_modules/github/test
+
+            if ( $LastExitCode -eq 0 ) {
+              # Exit the loop if tests passed (no need to retry if tests passed)
+              break
+            }
+          }
+        errorActionPreference: continue
+        displayName: Run tests
+        condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -26,6 +26,7 @@ jobs:
       - Windows_tests
       - Linux
       - macOS_tests
+      - macOS_tests_github
 
     variables:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Along with https://github.com/atom/github/pull/2617, unblocks https://github.com/atom/atom/pull/21782 _(also known as https://github.com/atom/github/issues/2607)_.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Move the `github` package tests out to their own CI job. This job manually runs `Atom --test` on the `github` package's test suite. It does so outside of `script/test`, which appears to avoid and work around the mysterious bug that's blocking progress in https://github.com/atom/atom/pull/21782.

Adds an env var `ATOM_PACKAGES_TO_SKIP` to `script/test`, allowing us to skip testing arbitrary packages by name -- This is used so that the `packages-1` test job doesn't attempt to run the `github` package tests, since it's being handled in the other job now. _(This is similar to the existing `ATOM_PACKAGES_TO_TEST` env var, and it does not conflict with any of the existing env vars or options to `script/test`. They all work together just fine.)_

There is another workaround required to get this to unblock https://github.com/atom/atom/pull/21782: Some other tests appear (perhaps unrelatedly?) to be failing under the new testing method. The additional workaround for that problem is in https://github.com/atom/github/pull/2617.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Stop running the `github` package tests here, and rely exclusively on the `atom/github` repo's CI
  - Disadvantageous, because if this repo breaks `github`'s CI, it could be caught much later, potentially after multiple unrelated PRs have been merged here, making bisecting issues very difficult. Could make maintaining both the `github` package and Atom core more fraught than need be.
- Discover the underlying issue and fix it rather than work around it
  - Multiple people have been stuck on this for weeks, so I don't think this will happen soon...

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

In https://github.com/atom/github/pull/2617, I propose to disable some tests that fail only in this repository's CI. The same tests pass over at the `github` package's own CI. So we begin to rely on the atom/github repo's CI a bit more heavily than before.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Many CI runs: https://dev.azure.com/DeeDeeG/b/_build?definitionId=17&branchFilter=129%2C144%2C146
- https://github.com/DeeDeeG/atom/commits/CI-separate-github-tests-job
- https://github.com/DeeDeeG/atom/commits/separate-github-tests-job

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A