### PR TITLE
Revert "Merge non word characters"

### DIFF
--- a/spec/text-mate-language-mode-spec.js
+++ b/spec/text-mate-language-mode-spec.js
@@ -1477,29 +1477,6 @@ describe('TextMateLanguageMode', () => {
       ]);
     }));
 
-  describe('.getNonWordCharacters', () => {
-    it('merges the language mode non word characters with the globally set non word characters', () => {
-      config.set('editor.nonWordCharacters', '»');
-
-      const buffer = atom.project.bufferForPathSync('sample.js');
-      const languageMode = new TextMateLanguageMode({
-        buffer,
-        config,
-        grammar: atom.grammars.grammarForScopeName('source.js')
-      });
-
-      const scopedNonWords = config.getRawScopedValue(
-        ['source.js'],
-        'editor.nonWordCharacters'
-      );
-      const globalNonWords = config.get('editor.nonWordCharacters');
-
-      expect(languageMode.getNonWordCharacters([0, 0])).toEqual(
-        `${scopedNonWords}${globalNonWords}`
-      );
-    });
-  });
-
   function simulateFold(ranges) {
     buffer.transact(() => {
       for (const range of ranges.reverse()) {

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -70,9 +70,7 @@ class TextMateLanguageMode {
 
   getNonWordCharacters(position) {
     const scope = this.scopeDescriptorForPosition(position);
-    const rawValue = this.config.getRawValue('editor.nonWordCharacters');
-    const scopedValue = this.config.get('editor.nonWordCharacters', { scope });
-    return `${scopedValue}${rawValue}`;
+    return this.config.get('editor.nonWordCharacters', { scope });
   }
 
   /*


### PR DESCRIPTION
This reverts commit a8b47528b836a7175aade5a9bcc925ce4fecc2c2.

>I think You should add a separate setting to add characters globally, not merging global with TextMate ones, for exactly that reason when one language has that character as part of the name and other doesn't. The current behaviour is not documented and a bit confusing.

cc: @KapitanOczywisty

https://github.com/atom/language-php/issues/92#issuecomment-765348037