### PR TITLE
Bump minidump @aminya/minidump@0.19.0-10

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-8",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-8.tgz",
-      "integrity": "sha512-DGHiexVHOeRFoWVczrfU+kNJTtjUCKu7Nv6DDVI/pdJO4w0d2y0BH8DS6JZIrAxnfxXjJcyQ4ilZfIYtZZR70w=="
+      "version": "npm:@aminya/minidump@0.19.0-9",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-9.tgz",
+      "integrity": "sha512-ObB5mbRcYpA7JpEw9SQqvR4Rbqy4t6iPZ1Rx8N+IPUDSdQr4q/9hTMAwuayyy4bQLyneXudN9mROfkVkyVYVDQ=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-9",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-9.tgz",
-      "integrity": "sha512-ObB5mbRcYpA7JpEw9SQqvR4Rbqy4t6iPZ1Rx8N+IPUDSdQr4q/9hTMAwuayyy4bQLyneXudN9mROfkVkyVYVDQ=="
+      "version": "npm:@aminya/minidump@0.19.0-10",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-10.tgz",
+      "integrity": "sha512-iVyQBaCLhWu9TkeHjvXRJXG+i4R4uiIN/fdo3SxzDUZnV7oTZ8+olnjkyHgAck75nuX4bcpLfZeLh8SawtRJgQ=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-8",
+    "minidump": "npm:@aminya/minidump@0.19.0-9",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-9",
+    "minidump": "npm:@aminya/minidump@0.19.0-10",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
### Description of the change

This updates minidump to 0.19.0-9. This release includes the prebuild binaries for minidump. 

The upstream PR:
https://github.com/electron/node-minidump/pull/42

### Benefits

- On MacOS, building Atom no longer needs a full Xcode installation for running the [xcodebuild](https://github.com/aminya/node-minidump/blob/aa24357c62d0959a1e718a3c61da2c893906be62/build.js#L51) script. 
- Faster Atom building on Linux and MacOS.
- Address the concerns in [this comment](https://github.com/atom/atom/pull/21792#issuecomment-768569398)

### Verification
The CI passes.

Here is the GitHub action that generated the binraies:
https://github.com/aminya/node-minidump/actions/runs/528992133


