### PR TITLE
Update the "open a file" dialog to use promises (doesn't take callbacks as of Electron 7) (for Electron 9 PR)

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -2015,7 +2015,13 @@ module.exports = class AtomApplication extends EventEmitter {
 
     // File dialog defaults to project directory of currently active editor
     if (path) openOptions.defaultPath = path;
-    dialog.showOpenDialog(parentWindow, openOptions, callback);
+    let promise = dialog.showOpenDialog(parentWindow, openOptions);
+    if (typeof callback === 'function') {
+      promise = promise.then(({ filePaths, bookmarks }) => {
+        callback(filePaths, bookmarks);
+      });
+    }
+    return promise;
   }
 
   async promptForRestart() {


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Can't open projects in the Electron 9 build of Atom.

- https://github.com/atom/atom/pull/21815#issuecomment-759780153
- https://github.com/atom/atom/pull/21777#issuecomment-747027422

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Use Promises instead of callbacks with the `dialog.showOpenDialog()` Electron API call.

Why? Because the Electron API changed. Many API calls don't accept callbacks anymore, and are meant to be used with Promises now. This happened starting in Electron 7.0.0, apparently.

See: 
- https://github.com/electron/electron/pull/17907
  - A big PR that removed lots of (previously deprecated) callback-based async APIs in favor of Promises, with separate and more-explicitly Sync versions available for some of the API calls. This landed in Electron 7.
- https://www.electronjs.org/docs/api/modernization/promisification
  - Overall documentation of moving many API calls to Promises

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None. But please review the specifics of this. I'm new to using Promises.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None. (But please review that I did this right.)

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I ran this change in dev mode using a build of the Electron 9 PR branch. I manually verified that projects can be added and files can be opened now using the "open a file" dialog.

Tested on macOS 10.15.7 Catalina.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A