### PR TITLE
fix: require .node files directly to detect incompatible native modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ node_modules
 docs/output
 docs/includes
 spec/fixtures/evil-files/
+!spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/node_modules/
 out/
 /electron/

--- a/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/main.js
+++ b/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/main.js
@@ -1,0 +1,6 @@
+const condition = false;
+
+if (condition) {
+    const { native } = require("./node_modules/native-module");
+    native(condition);
+}

--- a/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/node_modules/native-module/main.js
+++ b/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/node_modules/native-module/main.js
@@ -1,0 +1,7 @@
+exports.native = function loadNative(condition) {
+    if (condition) {
+        return require('../build/Release/native.node');
+    } else {
+        return null;
+    }
+}

--- a/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/node_modules/native-module/package.json
+++ b/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/node_modules/native-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "native-module",
+  "main": "./main.js"
+}

--- a/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/package.json
+++ b/spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-with-incompatible-native-module",
+  "version": "1.0.0",
+  "main": "./main.js"
+}

--- a/spec/package-spec.js
+++ b/spec/package-spec.js
@@ -45,6 +45,20 @@ describe('Package', function() {
       );
     });
 
+    it('detects the package as incompatible even if .node file is loaded conditionally', function() {
+      const packagePath = atom.project
+        .getDirectories()[0]
+        .resolve(
+          'packages/package-with-incompatible-native-module-loaded-conditionally'
+        );
+      const pack = buildPackage(packagePath);
+      expect(pack.isCompatible()).toBe(false);
+      expect(pack.incompatibleModules[0].name).toBe('native-module');
+      expect(pack.incompatibleModules[0].path).toBe(
+        path.join(packagePath, 'node_modules', 'native-module')
+      );
+    });
+
     it("utilizes _atomModuleCache if present to determine the package's native dependencies", function() {
       let packagePath = atom.project
         .getDirectories()[0]


### PR DESCRIPTION
### Description of the change

fix: require .node files directly to detect incompatible native modules
- This fixes the incompatible native module detection for the packages that require their `.node` files lazily
- Speeds up the performance of detection by directly require .node files instead of requiring the package

### Fixed Issues 
This bug is one of the reasons that all the terminal packages break whenever an **Electron upgrade** happens or when you don't use `apm rebuild`

An example of the packages that get fixed by this fix:
All the terminal packages that use `node-pty-prebuilt-multiarch`. Among them:
- https://github.com/atom-community/terminal
- x-terminal
- terminus
- atom-ink
- ...



There are many other issues. I need time to list all of them

### Verification
The CI passes.

A test you can do:

- Download x-terminal package as an example
- Run `npm rebuild` in its directory under `.atom/packages/x-terminal`
- Now run atom. You will see that it appears in the list of incompatible packages. Before this PR, the package just used to break without appearing in the rebuild list.

![image](https://user-images.githubusercontent.com/16418197/106846974-9a3ea100-6673-11eb-9260-051132db600a.png)
