### PR TITLE
Electron update related: fix showSaveDialog elector api for deprecated callback

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -464,13 +464,13 @@ module.exports = class AtomWindow extends EventEmitter {
       options
     );
 
+    let promise =  dialog.showSaveDialog(this.browserWindow, options);
     if (typeof callback === 'function') {
-      // Async
-      dialog.showSaveDialog(this.browserWindow, options, callback);
-    } else {
-      // Sync
-      return dialog.showSaveDialog(this.browserWindow, options);
+      promise = promise.then(({ filePath, bookmark }) => {
+        callback(filePath, bookmark);
+      });
     }
+    return promise;
   }
 
   toggleDevTools() {

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -464,7 +464,7 @@ module.exports = class AtomWindow extends EventEmitter {
       options
     );
 
-    let promise =  dialog.showSaveDialog(this.browserWindow, options);
+    let promise = dialog.showSaveDialog(this.browserWindow, options);
     if (typeof callback === 'function') {
       promise = promise.then(({ filePath, bookmark }) => {
         callback(filePath, bookmark);


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

Identify one usage of Dialog.showSaveDialog and remove the callback utilization since the callback is no more executed.
old doc where the callback is described:
https://github.com/electron/electron/blob/v5.0.13/docs/api/dialog.md#dialogshowsavedialogbrowserwindow-options-callback
new doc where showSaveDialog is promisified
https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowsavedialogbrowserwindow-options

There are those extra usage of `showSaveDialog`

https://github.com/atom/atom/blob/master/src/application-delegate.js#L274

In this case the `this.getCurrentWindow()` is `remote.getCurrentWindow()`, that returns a `BrowserWindow`.
https://www.electronjs.org/docs/api/remote#remotegetcurrentwindow

The BrowserWindow class does not seem to have a showSaveDialog, i m not sure if it inherits somehow the Dialog methods.

@DeeDeeG  any hint?

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->