### PR TITLE
Update use of session.resolveProxy() with a Promise instead of passing a callback (for Electron 9 PR)

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -802,11 +802,11 @@ module.exports = class AtomApplication extends EventEmitter {
     );
 
     this.disposable.add(
-      ipcHelpers.on(ipcMain, 'resolve-proxy', (event, requestId, url) => {
-        event.sender.session.resolveProxy(url).then(proxy => {
-          if (!event.sender.isDestroyed())
-            event.sender.send('did-resolve-proxy', requestId, proxy);
-        });
+      ipcHelpers.on(ipcMain, 'resolve-proxy', async (event, requestId, url) => {
+        const proxy = await event.sender.session.resolveProxy(url);
+        if (!event.sender.isDestroyed()) {
+          event.sender.send('did-resolve-proxy', requestId, proxy);
+        }
       })
     );
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -803,7 +803,7 @@ module.exports = class AtomApplication extends EventEmitter {
 
     this.disposable.add(
       ipcHelpers.on(ipcMain, 'resolve-proxy', (event, requestId, url) => {
-        event.sender.session.resolveProxy(url, proxy => {
+        event.sender.session.resolveProxy(url).then(proxy => {
           if (!event.sender.isDestroyed())
             event.sender.send('did-resolve-proxy', requestId, proxy);
         });


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

https://github.com/atom/atom/pull/21926#issuecomment-776195670

For the Electron 9 PR: https://github.com/atom/atom/pull/21777

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Don't pass a callback to `session.resolveProxy()`, move the "callback" code to after an `await` instead.

_Why? This Electron API call returns a Promise now, and as of Electron 7, it doesn't run callbacks passed to it._

_For documentation of this change, see: https://github.com/electron/electron/blob/v9.4.3/docs/api/modernization/promisification.md_

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

CI passes when this change is done on `master` branch: [CI run](https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1092). (It doesn't cause any new failures on the Electron 9 PR branch, either: [CI link](https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1093).)

(Using this Electron API call with Promises was optionally supported as of Electron 6, so `master` branch works with this change. It's only mandatory to use Promises starting in Electron 7 or newer.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A