### PR TITLE
⬆️ tree-sitter-rust@0.17.0 (doing #21790 over again)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4843,7 +4843,17 @@
     "language-rust-bundled": {
       "version": "file:packages/language-rust-bundled",
       "requires": {
-        "tree-sitter-rust": "^0.16.0"
+        "tree-sitter-rust": "^0.17.0"
+      },
+      "dependencies": {
+        "tree-sitter-rust": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.17.0.tgz",
+          "integrity": "sha512-dWYKrX4JbuLbKagTeCSsMZuFDKTzzaEHECsjLzIqbO/IhNHHLOzEcbF2YcIAGKG5thiT/lnNAjeOXDsILteCpg==",
+          "requires": {
+            "nan": "^2.8.0"
+          }
+        }
       }
     },
     "language-sass": {
@@ -8276,14 +8286,6 @@
             "readable-stream": "^3.1.1"
           }
         }
-      }
-    },
-    "tree-sitter-rust": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.16.0.tgz",
-      "integrity": "sha512-XzB/kJqrEJ6w6WnOn8d49yyzlQ8NXZ9bHCmKtX0mUB71cDMk/POCxiA4zsGb7Tv1R/im3Y+QsiY7UT4bl1lPYw==",
-      "requires": {
-        "nan": "^2.8.0"
       }
     },
     "tree-sitter-typescript": {

--- a/packages/language-rust-bundled/package.json
+++ b/packages/language-rust-bundled/package.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/atom/atom",
   "license": "MIT",
   "dependencies": {
-    "tree-sitter-rust": "^0.16.0"
+    "tree-sitter-rust": "^0.17.0"
   },
   "engines": {
     "atom": ">=1.0.0 <2.0.0"


### PR DESCRIPTION
> Fixes syntax highlighting bugs in:
> 1. https://github.com/atom/atom/issues/20884
> 2. https://github.com/atom/atom/issues/20897

(This is a re-do of https://github.com/atom/atom/pull/21790, which was reverted, but which can be landed again now that a tangentially related bug was fixed in https://github.com/atom/atom/pull/21884.)