### PR TITLE
Test, do not merge: Move npm to python3 by default for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,5 @@ RUN apt-get update && \
 # Update npm and dependencies
 RUN npm install -g npm --loglevel error
 
-# Use python2 by default
-RUN npm config set python /usr/bin/python2 -g
-
 ENTRYPOINT ["/usr/bin/env", "sh", "-c"]
 CMD ["bash"]


### PR DESCRIPTION
Let's see what CI does if we let it default to `python3` as the default for npm (no explicit configure necessary)