### PR TITLE
Disable Fedora's shebang mangling script when building the .rpm

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -13,6 +13,11 @@ Requires: lsb-core-noarch, libXss.so.1 libsecret-1.so.0, polkit
 Requires: lsb-core-noarch, libXss.so.1()(64bit) libsecret-1.so.0()(64bit), polkit
 %endif
 
+# Disable Fedora's shebang mangling script,
+# which errors out on any file with versionless `python` in its shebang
+# See: https://github.com/atom/atom/issues/21937
+%undefine __brp_mangle_shebangs
+
 %description
 <%= description %>
 


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Fixes: https://github.com/atom/atom/issues/21937

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Disable Fedora's shebang mangling script. (Which was being run when building the `.rpm` package on Fedora.)

<details><summary>A description of the script (click to expand)</summary>

Fedora's script tries to coerce all shebangs to point to exact, system-provided binaries.

For example: `#!/usr/bin/env sh` becomes `#!/usr/bin/sh`.

Starting with Fedora 30, the script errors out when it encounters ambiguous, versionless `python` in shebangs. (`python2` and `python3` are allowed.) For more about this error, see: https://github.com/atom/atom/issues/21937

For example, this shebang line causes an error: `#!/usr/bin/env python`.
(There are a bunch of those in [`node-gyp`](https://github.com/nodejs/node-gyp/blob/v7.1.2/gyp/gyp_main.py#L1).)

</details>

I'm proposing to disable this script, for two reasons:

1) Fedora users should be able to build the Atom `.rpm` package without errors.
2) Consistent shebangs in the Atom `.rpm` package, regardless of building on Debian/Ubuntu or Fedora.

See:
- https://github.com/atom/atom/issues/21937
- https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error
- https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_multiple_python_runtimes
- https://docs.fedoraproject.org/en-US/packaging-guidelines/#_shebang_lines
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/packaging_and_distributing_software/advanced-topics#python-shebang-mangling

### Possible Drawbacks

(This is mostly theoretical, as the `.rpm` package is built on Ubuntu in CI, where the shebang mangling script has never been available in the first place and has never been run. This PR has no effect on the official `.rpm` builds, but rather would make manual builds on Fedora consistent with the ones from our CI.)

Potential drawback for users who have been building on Fedora for some time already:  Lets more `#!/usr/bin/env` be used in shebang lines, so in theory if someone has a wonky `sh` or `python` on their PATH it could cause bugs. However, it is ultimately the user's responsibility to set their environment in a usable way. (Most people _don't_ put broken `sh` or `python` binaries on their PATH.) We don't change those shebangs in the `.deb` package, or the `.rpm` package built in CI, so I'd like to be consistent.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Run another script first, which changes "ambiguous" `python` in shebangs to `python3`. Lets the shebang mangling script run without errors. (https://github.com/DeeDeeG/atom/commit/cf3de253c05841cdd55ce632f2143521a826aaa3 / https://github.com/atom/atom/pull/21960)
- Manually mark certain shebangs as allowed, such as `#!/usr/bin/env python` from `node-gyp`.
- Update to the `node-gyp` v8 release some time in the future, where shebangs are planned to have `python3` instead of `python`. (Not possible until that is released!)

I chose to disable the shebang mangling script entirely, for consistent shebangs regardless of building Atom on Fedora or Debian/Ubuntu.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Manually tested that the Atom `.rpm` package builds and works correctly on Fedora with this change. `apm` can still install packages with this change. The Atom `.rpm` package still builds on Ubuntu with this change.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A