### PR TITLE
Fix  git diff subscriptions

### DIFF
--- a/packages/git-diff/lib/diff-list-view.js
+++ b/packages/git-diff/lib/diff-list-view.js
@@ -1,7 +1,9 @@
-const SelectListView = require('atom-select-list');
-const { repositoryForPath } = require('./helpers');
+'use babel';
 
-module.exports = class DiffListView {
+import SelectListView from 'atom-select-list';
+import repositoryForPath from './helpers';
+
+export default class DiffListView {
   constructor() {
     this.selectListView = new SelectListView({
       emptyMessage: 'No diffs in file',
@@ -84,4 +86,4 @@ module.exports = class DiffListView {
       this.attach();
     }
   }
-};
+}

--- a/packages/git-diff/lib/diff-list-view.js
+++ b/packages/git-diff/lib/diff-list-view.js
@@ -71,7 +71,7 @@ export default class DiffListView {
       this.cancel();
     } else if (editor) {
       this.editor = editor;
-      const repository = repositoryForPath(this.editor.getPath());
+      const repository = await repositoryForPath(this.editor.getPath());
       let diffs = repository
         ? repository.getLineDiffs(this.editor.getPath(), this.editor.getText())
         : [];

--- a/packages/git-diff/lib/diff-list-view.js
+++ b/packages/git-diff/lib/diff-list-view.js
@@ -6,8 +6,8 @@ module.exports = class DiffListView {
     this.selectListView = new SelectListView({
       emptyMessage: 'No diffs in file',
       items: [],
-      filterKeyForItem: diff => diff.lineText,
-      elementForItem: diff => {
+      filterKeyForItem: (diff) => diff.lineText,
+      elementForItem: (diff) => {
         const li = document.createElement('li');
         li.classList.add('two-lines');
 
@@ -18,29 +18,27 @@ module.exports = class DiffListView {
 
         const secondaryLine = document.createElement('div');
         secondaryLine.classList.add('secondary-line');
-        secondaryLine.textContent = `-${diff.oldStart},${diff.oldLines} +${
-          diff.newStart
-        },${diff.newLines}`;
+        secondaryLine.textContent = `-${diff.oldStart},${diff.oldLines} +${diff.newStart},${diff.newLines}`;
         li.appendChild(secondaryLine);
 
         return li;
       },
-      didConfirmSelection: diff => {
+      didConfirmSelection: (diff) => {
         this.cancel();
         const bufferRow = diff.newStart > 0 ? diff.newStart - 1 : diff.newStart;
         this.editor.setCursorBufferPosition([bufferRow, 0], {
-          autoscroll: true
+          autoscroll: true,
         });
         this.editor.moveToFirstCharacterOfLine();
       },
       didCancelSelection: () => {
         this.cancel();
-      }
+      },
     });
     this.selectListView.element.classList.add('diff-list-view');
     this.panel = atom.workspace.addModalPanel({
       item: this.selectListView,
-      visible: false
+      visible: false,
     });
   }
 

--- a/packages/git-diff/lib/diff-list-view.js
+++ b/packages/git-diff/lib/diff-list-view.js
@@ -8,8 +8,8 @@ export default class DiffListView {
     this.selectListView = new SelectListView({
       emptyMessage: 'No diffs in file',
       items: [],
-      filterKeyForItem: (diff) => diff.lineText,
-      elementForItem: (diff) => {
+      filterKeyForItem: diff => diff.lineText,
+      elementForItem: diff => {
         const li = document.createElement('li');
         li.classList.add('two-lines');
 
@@ -20,27 +20,29 @@ export default class DiffListView {
 
         const secondaryLine = document.createElement('div');
         secondaryLine.classList.add('secondary-line');
-        secondaryLine.textContent = `-${diff.oldStart},${diff.oldLines} +${diff.newStart},${diff.newLines}`;
+        secondaryLine.textContent = `-${diff.oldStart},${diff.oldLines} +${
+          diff.newStart
+        },${diff.newLines}`;
         li.appendChild(secondaryLine);
 
         return li;
       },
-      didConfirmSelection: (diff) => {
+      didConfirmSelection: diff => {
         this.cancel();
         const bufferRow = diff.newStart > 0 ? diff.newStart - 1 : diff.newStart;
         this.editor.setCursorBufferPosition([bufferRow, 0], {
-          autoscroll: true,
+          autoscroll: true
         });
         this.editor.moveToFirstCharacterOfLine();
       },
       didCancelSelection: () => {
         this.cancel();
-      },
+      }
     });
     this.selectListView.element.classList.add('diff-list-view');
     this.panel = atom.workspace.addModalPanel({
       item: this.selectListView,
-      visible: false,
+      visible: false
     });
   }
 

--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -68,6 +68,9 @@ export default class GitDiffView {
     this._animationId = null;
   }
 
+  /**
+   * @describe handles all subscriptions based on the repository in focus
+   */
   async subscribeToRepository() {
     if (this._repoSubs != null) {
       this._repoSubs.dispose();

--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -1,66 +1,108 @@
 'use babel';
 
-import CompositeDisposable from 'atom';
+import { CompositeDisposable } from 'atom';
 import repositoryForPath from './helpers';
 
 const MAX_BUFFER_LENGTH_TO_DIFF = 2 * 1024 * 1024;
 
 export default class GitDiffView {
   constructor(editor) {
-    this.updateDiffs = this.updateDiffs.bind(this);
-    this.editor = editor;
+    // These are the only members guaranteed to exist.
     this.subscriptions = new CompositeDisposable();
-    this.decorations = {};
-    this.markers = [];
-  }
+    this.editor = editor;
+    this.repository = null;
+    this.markers = new WeakMap();
 
-  start() {
-    const editorElement = this.editor.getElement();
+    // I know this looks janky but it works. Class methods are available
+    // before the constructor is executed. It's a micro-opt above lambdas.
+    const subscribeToRepository = this.subscribeToRepository.bind(this);
+    // WARNING: This gets handed to setImmediate, so it must be bound.
+    this.updateDiffs = this.updateDiffs.bind(this);
 
-    this.subscribeToRepository();
+    subscribeToRepository();
 
     this.subscriptions.add(
-      this.editor.onDidStopChanging(this.updateDiffs),
-      this.editor.onDidChangePath(this.updateDiffs),
-      atom.project.onDidChangePaths(() => this.subscribeToRepository()),
-      atom.commands.add(editorElement, 'git-diff:move-to-next-diff', () =>
-        this.moveToNextDiff()
-      ),
-      atom.commands.add(editorElement, 'git-diff:move-to-previous-diff', () =>
-        this.moveToPreviousDiff()
-      ),
-      atom.config.onDidChange('git-diff.showIconsInEditorGutter', () =>
-        this.updateIconDecoration()
-      ),
-      atom.config.onDidChange('editor.showLineNumbers', () =>
-        this.updateIconDecoration()
-      ),
-      editorElement.onDidAttach(() => this.updateIconDecoration()),
-      this.editor.onDidDestroy(() => {
-        this.cancelUpdate();
-        this.removeDecorations();
-        this.subscriptions.dispose();
-      })
+      atom.project.onDidChangePaths(subscribeToRepository)
     );
+  }
 
-    this.updateIconDecoration();
-    this.scheduleUpdate();
+  destroy() {
+    // This entire object will be free soon, no need to release here.
+    if (this._repoSubs != null) this._repoSubs.dispose();
+    this.subscriptions.dispose();
+
+    if (this._animationId != null) cancelAnimationFrame(this._animationId);
+
+    if (this.diffs)
+      for (const diff of this.diffs) this.markers.get(diff).destroy();
+  }
+
+  async subscribeToRepository() {
+    if (this._repoSubs != null) this._repoSubs.dispose();
+
+    this.repository = await repositoryForPath(this.editor.getPath());
+    if (this.repository != null) {
+      const editorElm = atom.views.getView(this.editor);
+
+      const subscribeToRepository = this.subscribeToRepository.bind(this);
+      const updateIconDecoration = this.updateIconDecoration.bind(this);
+      const scheduleUpdate = this.scheduleUpdate.bind(this);
+      // Every time the repo is changed, the editor needs to be reinitialized.
+      this._repoSubs = new CompositeDisposable(
+        this.repository.onDidDestroy(subscribeToRepository),
+        this.repository.onDidChangeStatuses(scheduleUpdate),
+        this.repository.onDidChangeStatus((changedPath) => {
+          if (changedPath === this.editor.getPath()) scheduleUpdate();
+        }),
+        this.editor.onDidStopChanging(scheduleUpdate),
+        this.editor.onDidChangePath(scheduleUpdate),
+        atom.commands.add(
+          editorElm,
+          'git-diff:move-to-next-diff',
+          this.moveToNextDiff.bind(this)
+        ),
+        atom.commands.add(
+          editorElm,
+          'git-diff:move-to-previous-diff',
+          this.moveToPreviousDiff.bind(this)
+        ),
+        atom.config.onDidChange(
+          'git-diff.showIconsInEditorGutter',
+          updateIconDecoration
+        ),
+        atom.config.onDidChange('editor.showLineNumbers', updateIconDecoration),
+        editorElm.onDidAttach(updateIconDecoration)
+      );
+
+      updateIconDecoration();
+      scheduleUpdate();
+    } else {
+      // Do complete teardown and release of old repository related objects.
+      if (this._animationId) cancelAnimationFrame(this._animationId);
+      if (this.diffs) {
+        for (const diff of this.diffs) this.markers.get(diff).destroy();
+        this.diffs = null;
+      }
+      if (this._repoSubs) {
+        this._repoSubs.dispose();
+        this._repoSubs = null;
+      }
+    }
   }
 
   moveToNextDiff() {
     const cursorLineNumber = this.editor.getCursorBufferPosition().row + 1;
     let nextDiffLineNumber = null;
     let firstDiffLineNumber = null;
-    if (this.diffs) {
-      for (const { newStart } of this.diffs) {
-        if (newStart > cursorLineNumber) {
-          if (nextDiffLineNumber == null) nextDiffLineNumber = newStart - 1;
-          nextDiffLineNumber = Math.min(newStart - 1, nextDiffLineNumber);
-        }
 
-        if (firstDiffLineNumber == null) firstDiffLineNumber = newStart - 1;
-        firstDiffLineNumber = Math.min(newStart - 1, firstDiffLineNumber);
+    for (const { newStart } of this.diffs) {
+      if (newStart > cursorLineNumber) {
+        if (nextDiffLineNumber == null) nextDiffLineNumber = newStart - 1;
+        nextDiffLineNumber = Math.min(newStart - 1, nextDiffLineNumber);
       }
+
+      if (firstDiffLineNumber == null) firstDiffLineNumber = newStart - 1;
+      firstDiffLineNumber = Math.min(newStart - 1, firstDiffLineNumber);
     }
 
     // Wrap around to the first diff in the file
@@ -74,8 +116,31 @@ export default class GitDiffView {
     this.moveToLineNumber(nextDiffLineNumber);
   }
 
+  moveToPreviousDiff() {
+    const cursorLineNumber = this.editor.getCursorBufferPosition().row + 1;
+    let previousDiffLineNumber = null;
+    let lastDiffLineNumber = null;
+    for (const { newStart } of this.diffs) {
+      if (newStart < cursorLineNumber) {
+        previousDiffLineNumber = Math.max(newStart - 1, previousDiffLineNumber);
+      }
+      lastDiffLineNumber = Math.max(newStart - 1, lastDiffLineNumber);
+    }
+
+    // Wrap around to the last diff in the file
+    if (
+      atom.config.get('git-diff.wrapAroundOnMoveToDiff') &&
+      previousDiffLineNumber === null
+    ) {
+      previousDiffLineNumber = lastDiffLineNumber;
+    }
+
+    this.moveToLineNumber(previousDiffLineNumber);
+  }
+
   updateIconDecoration() {
-    const gutter = this.editor.getElement().querySelector('.gutter');
+    const editorElement = atom.views.getView(this.editor);
+    const gutter = editorElement.querySelector('.gutter');
     if (gutter) {
       if (
         atom.config.get('editor.showLineNumbers') &&
@@ -88,101 +153,58 @@ export default class GitDiffView {
     }
   }
 
-  moveToPreviousDiff() {
-    const cursorLineNumber = this.editor.getCursorBufferPosition().row + 1;
-    let previousDiffLineNumber = -1;
-    let lastDiffLineNumber = -1;
-    if (this.diffs) {
-      for (const { newStart } of this.diffs) {
-        if (newStart < cursorLineNumber) {
-          previousDiffLineNumber = Math.max(
-            newStart - 1,
-            previousDiffLineNumber
-          );
-        }
-        lastDiffLineNumber = Math.max(newStart - 1, lastDiffLineNumber);
-      }
-    }
-
-    // Wrap around to the last diff in the file
-    if (
-      atom.config.get('git-diff.wrapAroundOnMoveToDiff') &&
-      previousDiffLineNumber === -1
-    ) {
-      previousDiffLineNumber = lastDiffLineNumber;
-    }
-
-    this.moveToLineNumber(previousDiffLineNumber);
-  }
-
   moveToLineNumber(lineNumber) {
-    if (lineNumber != null && lineNumber >= 0) {
+    if (lineNumber != null) {
       this.editor.setCursorBufferPosition([lineNumber, 0]);
       this.editor.moveToFirstCharacterOfLine();
     }
   }
 
-  subscribeToRepository() {
-    this.repository = repositoryForPath(this.editor.getPath());
-    if (this.repository) {
-      this.subscriptions.add(
-        this.repository.onDidChangeStatuses(() => {
-          this.scheduleUpdate();
-        })
-      );
-      this.subscriptions.add(
-        this.repository.onDidChangeStatus((changedPath) => {
-          if (changedPath === this.editor.getPath()) this.scheduleUpdate();
-        })
-      );
-    }
-  }
-
-  cancelUpdate() {
-    clearImmediate(this.immediateId);
-  }
-
   scheduleUpdate() {
-    this.cancelUpdate();
-    this.immediateId = setImmediate(this.updateDiffs);
+    // Use Chromium native requestAnimationFrame because it yields
+    // to the browser, is standard and doesn't involve extra JS overhead.
+    if (this._animationId) cancelAnimationFrame(this._animationId);
+    this._animationId = requestAnimationFrame(this.updateDiffs);
   }
 
+  // Should only be called when there is a repository
   updateDiffs() {
-    if (this.editor.isDestroyed()) return;
-    this.removeDecorations();
-    const path = this.editor && this.editor.getPath();
-    if (
-      path &&
-      this.editor.getBuffer().getLength() < MAX_BUFFER_LENGTH_TO_DIFF
-    ) {
-      this.diffs =
-        this.repository &&
-        this.repository.getLineDiffs(path, this.editor.getText());
-      if (this.diffs) this.addDecorations(this.diffs);
-    }
-  }
+    const bufferLength = this.editor.getBuffer().getLength();
+    if (bufferLength < MAX_BUFFER_LENGTH_TO_DIFF) {
+      const path = this.editor.getPath();
 
-  addDecorations(diffs) {
-    for (const { newStart, oldLines, newLines } of diffs) {
-      const startRow = newStart - 1;
-      const endRow = newStart + newLines - 1;
-      if (oldLines === 0 && newLines > 0) {
-        this.markRange(startRow, endRow, 'git-line-added');
-      } else if (newLines === 0 && oldLines > 0) {
-        if (startRow < 0) {
-          this.markRange(0, 0, 'git-previous-line-removed');
+      // Before we redraw the diffs, tear down the old markers.
+      if (this.diffs)
+        for (const diff of this.diffs) this.markers.get(diff).destroy();
+
+      // WARNING: Could cause future memory leak if git-utils ever
+      // changes their diff strategy to one that re-uses diffs between
+      // requests. But that's unlikely to happen.
+      this.diffs = this.repository.getLineDiffs(path, this.editor.getText());
+      this.diffs = this.diffs || []; // Sanitize type to array.
+
+      for (let i = 0; i < this.diffs.length; i++) {
+        const { newStart, oldLines, newLines } = this.diffs[i];
+        const startRow = newStart - 1;
+        const endRow = newStart + newLines - 1;
+
+        let mark;
+
+        if (oldLines === 0 && newLines > 0) {
+          mark = this.markRange(startRow, endRow, 'git-line-added');
+        } else if (newLines === 0 && oldLines > 0) {
+          if (startRow < 0) {
+            mark = this.markRange(0, 0, 'git-previous-line-removed');
+          } else {
+            mark = this.markRange(startRow, startRow, 'git-line-removed');
+          }
         } else {
-          this.markRange(startRow, startRow, 'git-line-removed');
+          mark = this.markRange(startRow, endRow, 'git-line-modified');
         }
-      } else {
-        this.markRange(startRow, endRow, 'git-line-modified');
+
+        this.markers.set(this.diffs[i], mark);
       }
     }
-  }
-
-  removeDecorations() {
-    for (let marker of this.markers) marker.destroy();
-    this.markers = [];
   }
 
   markRange(startRow, endRow, klass) {
@@ -196,6 +218,6 @@ export default class GitDiffView {
       }
     );
     this.editor.decorateMarker(marker, { type: 'line-number', class: klass });
-    this.markers.push(marker);
+    return marker;
   }
 }

--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -56,12 +56,10 @@ export default class GitDiffView {
    *   Example: this.diffs only exists when we have a repository.
    */
   destroyChildren() {
-    if (this._animationId)
-      cancelAnimationFrame(this._animationId);
+    if (this._animationId) cancelAnimationFrame(this._animationId);
 
     if (this.diffs)
-      for (const diff of this.diffs)
-        this.markers.get(diff).destroy();
+      for (const diff of this.diffs) this.markers.get(diff).destroy();
   }
 
   /**
@@ -102,8 +100,7 @@ export default class GitDiffView {
         this.repository.onDidDestroy(subscribeToRepository),
         this.repository.onDidChangeStatuses(scheduleUpdate),
         this.repository.onDidChangeStatus(changedPath => {
-          if (changedPath === this.editorPath)
-            scheduleUpdate();
+          if (changedPath === this.editorPath) scheduleUpdate();
         }),
         this.editor.onDidStopChanging(scheduleUpdate),
         this.editor.onDidChangePath(() => {
@@ -147,14 +144,12 @@ export default class GitDiffView {
 
     for (const { newStart } of this.diffs) {
       if (newStart > cursorLineNumber) {
-        if (nextDiffLineNumber == null)
-          nextDiffLineNumber = newStart - 1;
+        if (nextDiffLineNumber == null) nextDiffLineNumber = newStart - 1;
 
         nextDiffLineNumber = Math.min(newStart - 1, nextDiffLineNumber);
       }
 
-      if (firstDiffLineNumber == null)
-        firstDiffLineNumber = newStart - 1;
+      if (firstDiffLineNumber == null) firstDiffLineNumber = newStart - 1;
 
       firstDiffLineNumber = Math.min(newStart - 1, firstDiffLineNumber);
     }
@@ -216,8 +211,7 @@ export default class GitDiffView {
   scheduleUpdate() {
     // Use Chromium native requestAnimationFrame because it yields
     // to the browser, is standard and doesn't involve extra JS overhead.
-    if (this._animationId)
-      cancelAnimationFrame(this._animationId);
+    if (this._animationId) cancelAnimationFrame(this._animationId);
 
     this._animationId = requestAnimationFrame(this.updateDiffs);
   }
@@ -231,8 +225,7 @@ export default class GitDiffView {
     if (this.buffer.getLength() < MAX_BUFFER_LENGTH_TO_DIFF) {
       // Before we redraw the diffs, tear down the old markers.
       if (this.diffs)
-        for (const diff of this.diffs)
-          this.markers.get(diff).destroy();
+        for (const diff of this.diffs) this.markers.get(diff).destroy();
 
       this.markers.clear();
 

--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -76,7 +76,7 @@ export default class GitDiffView {
 
     this.repository = await repositoryForPath(this.editor.getPath());
     if (this.repository != null) {
-      const editorElm = atom.views.getView(this.editor);
+      const editorElement = atom.views.getView(this.editor);
 
       const subscribeToRepository = this.subscribeToRepository.bind(this);
       const updateIconDecoration = this.updateIconDecoration.bind(this);
@@ -93,12 +93,12 @@ export default class GitDiffView {
           this.editor.onDidStopChanging(scheduleUpdate),
           this.editor.onDidChangePath(scheduleUpdate),
           atom.commands.add(
-            editorElm,
+            editorElement,
             'git-diff:move-to-next-diff',
             this.moveToNextDiff.bind(this)
           ),
           atom.commands.add(
-            editorElm,
+            editorElement,
             'git-diff:move-to-previous-diff',
             this.moveToPreviousDiff.bind(this)
           ),
@@ -110,7 +110,7 @@ export default class GitDiffView {
             'editor.showLineNumbers',
             updateIconDecoration
           ),
-          editorElm.onDidAttach(updateIconDecoration)
+          editorElement.onDidAttach(updateIconDecoration)
         ))
       );
 
@@ -219,8 +219,8 @@ export default class GitDiffView {
       this.diffs = this.repository.getLineDiffs(path, this.editor.getText());
       this.diffs = this.diffs || []; // Sanitize type to array.
 
-      for (let i = 0; i < this.diffs.length; i++) {
-        const { newStart, oldLines, newLines } = this.diffs[i];
+      for (const diff of this.diffs) {
+        const { newStart, oldLines, newLines } = diff;
         const startRow = newStart - 1;
         const endRow = newStart + newLines - 1;
 
@@ -238,7 +238,7 @@ export default class GitDiffView {
           mark = this.markRange(startRow, endRow, 'git-line-modified');
         }
 
-        this.markers.set(this.diffs[i], mark);
+        this.markers.set(diff, mark);
       }
     }
   }

--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -1,9 +1,11 @@
-const { CompositeDisposable } = require('atom');
-const { repositoryForPath } = require('./helpers');
+'use babel';
+
+import CompositeDisposable from 'atom';
+import repositoryForPath from './helpers';
 
 const MAX_BUFFER_LENGTH_TO_DIFF = 2 * 1024 * 1024;
 
-module.exports = class GitDiffView {
+export default class GitDiffView {
   constructor(editor) {
     this.updateDiffs = this.updateDiffs.bind(this);
     this.editor = editor;
@@ -196,4 +198,4 @@ module.exports = class GitDiffView {
     this.editor.decorateMarker(marker, { type: 'line-number', class: klass });
     this.markers.push(marker);
   }
-};
+}

--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -129,7 +129,7 @@ module.exports = class GitDiffView {
         })
       );
       this.subscriptions.add(
-        this.repository.onDidChangeStatus(changedPath => {
+        this.repository.onDidChangeStatus((changedPath) => {
           if (changedPath === this.editor.getPath()) this.scheduleUpdate();
         })
       );
@@ -184,9 +184,15 @@ module.exports = class GitDiffView {
   }
 
   markRange(startRow, endRow, klass) {
-    const marker = this.editor.markBufferRange([[startRow, 0], [endRow, 0]], {
-      invalidate: 'never'
-    });
+    const marker = this.editor.markBufferRange(
+      [
+        [startRow, 0],
+        [endRow, 0],
+      ],
+      {
+        invalidate: 'never',
+      }
+    );
     this.editor.decorateMarker(marker, { type: 'line-number', class: klass });
     this.markers.push(marker);
   }

--- a/packages/git-diff/lib/helpers.js
+++ b/packages/git-diff/lib/helpers.js
@@ -1,4 +1,4 @@
-exports.repositoryForPath = function(goalPath) {
+exports.repositoryForPath = function (goalPath) {
   const directories = atom.project.getDirectories();
   const repositories = atom.project.getRepositories();
   for (let i = 0; i < directories.length; i++) {

--- a/packages/git-diff/lib/helpers.js
+++ b/packages/git-diff/lib/helpers.js
@@ -1,4 +1,4 @@
-exports.repositoryForPath = function (goalPath) {
+export default function (goalPath) {
   const directories = atom.project.getDirectories();
   const repositories = atom.project.getRepositories();
   for (let i = 0; i < directories.length; i++) {
@@ -8,4 +8,4 @@ exports.repositoryForPath = function (goalPath) {
     }
   }
   return null;
-};
+}

--- a/packages/git-diff/lib/helpers.js
+++ b/packages/git-diff/lib/helpers.js
@@ -1,6 +1,6 @@
 'use babel';
 
-export default async function (goalPath) {
+export default async function(goalPath) {
   for (const directory of atom.project.getDirectories()) {
     if (goalPath === directory.getPath() || directory.contains(goalPath)) {
       return atom.project.repositoryForDirectory(directory);

--- a/packages/git-diff/lib/helpers.js
+++ b/packages/git-diff/lib/helpers.js
@@ -1,10 +1,9 @@
-export default function (goalPath) {
-  const directories = atom.project.getDirectories();
-  const repositories = atom.project.getRepositories();
-  for (let i = 0; i < directories.length; i++) {
-    const directory = directories[i];
+'use babel';
+
+export default async function (goalPath) {
+  for (const directory of atom.project.getDirectories()) {
     if (goalPath === directory.getPath() || directory.contains(goalPath)) {
-      return repositories[i];
+      return atom.project.repositoryForDirectory(directory);
     }
   }
   return null;

--- a/packages/git-diff/lib/main.js
+++ b/packages/git-diff/lib/main.js
@@ -43,7 +43,7 @@ export default {
   deactivate() {
     diffListView = null;
 
-    for (const v of diffViews) v.destroy();
+    for (const diffView of diffViews) diffView.destroy();
     diffViews = null;
 
     subscriptions.dispose();

--- a/packages/git-diff/lib/main.js
+++ b/packages/git-diff/lib/main.js
@@ -15,7 +15,7 @@ export default {
 
     subscriptions.add(
       atom.workspace.observeTextEditors(editor => {
-        const editorElm = atom.views.getView(editor);
+        const editorElement = atom.views.getView(editor);
         const diffView = new GitDiffView(editor);
 
         diffViews.add(diffView);
@@ -24,7 +24,7 @@ export default {
         const command = 'git-diff:toggle-diff-list';
         subscriptions.add(
           (editorSubs = new CompositeDisposable(
-            atom.commands.add(editorElm, command, () => {
+            atom.commands.add(editorElement, command, () => {
               if (diffListView == null) diffListView = new DiffListView();
               diffListView.toggle();
             }),

--- a/packages/git-diff/lib/main.js
+++ b/packages/git-diff/lib/main.js
@@ -22,8 +22,7 @@ export default {
         const listViewCommand = 'git-diff:toggle-diff-list';
         const editorSubs = new CompositeDisposable(
           atom.commands.add(editorElement, listViewCommand, () => {
-            if (diffListView == null)
-              diffListView = new DiffListView();
+            if (diffListView == null) diffListView = new DiffListView();
 
             diffListView.toggle();
           }),
@@ -43,8 +42,7 @@ export default {
   deactivate() {
     diffListView = null;
 
-    for (const diffView of diffViews)
-      diffView.destroy();
+    for (const diffView of diffViews) diffView.destroy();
 
     diffViews.clear();
 

--- a/packages/git-diff/lib/main.js
+++ b/packages/git-diff/lib/main.js
@@ -1,9 +1,11 @@
-const GitDiffView = require('./git-diff-view');
-const DiffListView = require('./diff-list-view');
+'use babel';
+
+import GitDiffView from './git-diff-view';
+import DiffListView from './diff-list-view';
 
 let diffListView = null;
 
-module.exports = {
+export default {
   activate() {
     const watchedEditors = new WeakSet();
 

--- a/packages/git-diff/lib/main.js
+++ b/packages/git-diff/lib/main.js
@@ -14,7 +14,7 @@ export default {
     diffViews = new Set();
 
     subscriptions.add(
-      atom.workspace.observeTextEditors((editor) => {
+      atom.workspace.observeTextEditors(editor => {
         const editorElm = atom.views.getView(editor);
         const diffView = new GitDiffView(editor);
 
@@ -48,5 +48,5 @@ export default {
 
     subscriptions.dispose();
     subscriptions = null;
-  },
+  }
 };

--- a/packages/git-diff/lib/main.js
+++ b/packages/git-diff/lib/main.js
@@ -7,7 +7,7 @@ module.exports = {
   activate() {
     const watchedEditors = new WeakSet();
 
-    atom.workspace.observeTextEditors(editor => {
+    atom.workspace.observeTextEditors((editor) => {
       if (watchedEditors.has(editor)) return;
 
       new GitDiffView(editor).start();
@@ -28,5 +28,5 @@ module.exports = {
   deactivate() {
     if (diffListView) diffListView.destroy();
     diffListView = null;
-  }
+  },
 };

--- a/packages/git-diff/package.json
+++ b/packages/git-diff/package.json
@@ -9,27 +9,11 @@
     "atom": "*"
   },
   "dependencies": {
-    "atom-select-list": "^0.7.0",
-    "fs-plus": "^3.0.0",
-    "temp": "~0.8.1"
+    "atom-select-list": "^0.7.0"
   },
   "devDependencies": {
-    "standard": "^11.0.0"
-  },
-  "standard": {
-    "ignore": [
-      "spec/fixtures/working-dir/sample.js"
-    ],
-    "env": {
-      "atomtest": true,
-      "browser": true,
-      "jasmine": true,
-      "node": true
-    },
-    "globals": [
-      "atom",
-      "snapshotResult"
-    ]
+    "fs-plus": "^3.0.0",
+    "temp": "~0.8.1"
   },
   "configSchema": {
     "showIconsInEditorGutter": {

--- a/packages/git-diff/spec/diff-list-view-spec.js
+++ b/packages/git-diff/spec/diff-list-view-spec.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs-plus');
-const temp = require('temp');
+const temp = require('temp').track();
 
 describe('git-diff:toggle-diff-list', () => {
   let diffListView, editor;

--- a/packages/git-diff/spec/git-diff-spec.js
+++ b/packages/git-diff/spec/git-diff-spec.js
@@ -3,10 +3,15 @@ const fs = require('fs-plus');
 const temp = require('temp').track();
 
 describe('GitDiff package', () => {
-  let editor, editorElement, projectPath;
+  let editor, editorElement, projectPath, screenUpdates;
 
   beforeEach(() => {
-    spyOn(window, 'setImmediate').andCallFake((fn) => fn());
+    screenUpdates = 0;
+    spyOn(window, 'requestAnimationFrame').andCallFake((fn) => {
+      fn();
+      screenUpdates++;
+    });
+    spyOn(window, 'cancelAnimationFrame').andCallFake((i) => null);
 
     projectPath = temp.mkdirSync('git-diff-spec-');
     const otherPath = temp.mkdirSync('some-other-path-');
@@ -20,16 +25,26 @@ describe('GitDiff package', () => {
 
     jasmine.attachToDOM(atom.workspace.getElement());
 
-    waitsForPromise(() =>
-      atom.workspace.open(path.join(projectPath, 'sample.js'))
-    );
+    waitsForPromise(async () => {
+      await atom.workspace.open(path.join(projectPath, 'sample.js'));
+      await atom.packages.activatePackage('git-diff');
+    });
 
     runs(() => {
       editor = atom.workspace.getActiveTextEditor();
-      editorElement = editor.getElement();
+      editorElement = atom.views.getView(editor);
     });
+  });
 
-    waitsForPromise(() => atom.packages.activatePackage('git-diff'));
+  afterEach(() => {
+    temp.cleanup();
+  });
+
+  describe('when the editor has no changes', () => {
+    it("doesn't mark the editor", () => {
+      waitsFor(() => screenUpdates > 0);
+      runs(() => expect(editor.getMarkers().length).toBe(0));
+    });
   });
 
   describe('when the editor has modified lines', () => {
@@ -39,13 +54,17 @@ describe('GitDiff package', () => {
       );
       editor.insertText('a');
       advanceClock(editor.getBuffer().stoppedChangingDelay);
-      expect(editorElement.querySelectorAll('.git-line-modified').length).toBe(
-        1
-      );
-      expect(editorElement.querySelector('.git-line-modified')).toHaveData(
-        'buffer-row',
-        0
-      );
+
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-line-modified').length
+        ).toBe(1);
+        expect(editorElement.querySelector('.git-line-modified')).toHaveData(
+          'buffer-row',
+          0
+        );
+      });
     });
   });
 
@@ -56,11 +75,16 @@ describe('GitDiff package', () => {
       editor.insertNewline();
       editor.insertText('a');
       advanceClock(editor.getBuffer().stoppedChangingDelay);
-      expect(editorElement.querySelectorAll('.git-line-added').length).toBe(1);
-      expect(editorElement.querySelector('.git-line-added')).toHaveData(
-        'buffer-row',
-        1
-      );
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(editorElement.querySelectorAll('.git-line-added').length).toBe(
+          1
+        );
+        expect(editorElement.querySelector('.git-line-added')).toHaveData(
+          'buffer-row',
+          1
+        );
+      });
     });
   });
 
@@ -70,13 +94,16 @@ describe('GitDiff package', () => {
       editor.setCursorBufferPosition([5]);
       editor.deleteLine();
       advanceClock(editor.getBuffer().stoppedChangingDelay);
-      expect(editorElement.querySelectorAll('.git-line-removed').length).toBe(
-        1
-      );
-      expect(editorElement.querySelector('.git-line-removed')).toHaveData(
-        'buffer-row',
-        4
-      );
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(editorElement.querySelectorAll('.git-line-removed').length).toBe(
+          1
+        );
+        expect(editorElement.querySelector('.git-line-removed')).toHaveData(
+          'buffer-row',
+          4
+        );
+      });
     });
   });
 
@@ -86,12 +113,15 @@ describe('GitDiff package', () => {
       editor.setCursorBufferPosition([0, 0]);
       editor.deleteLine();
       advanceClock(editor.getBuffer().stoppedChangingDelay);
-      expect(
-        editorElement.querySelectorAll('.git-previous-line-removed').length
-      ).toBe(1);
-      expect(
-        editorElement.querySelector('.git-previous-line-removed')
-      ).toHaveData('buffer-row', 0);
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-previous-line-removed').length
+        ).toBe(1);
+        expect(
+          editorElement.querySelector('.git-previous-line-removed')
+        ).toHaveData('buffer-row', 0);
+      });
     });
   });
 
@@ -102,14 +132,24 @@ describe('GitDiff package', () => {
       );
       editor.insertText('a');
       advanceClock(editor.getBuffer().stoppedChangingDelay);
-      expect(editorElement.querySelectorAll('.git-line-modified').length).toBe(
-        1
+      waitsFor(
+        () => editorElement.querySelectorAll('.git-line-modified').length > 0
       );
-      editor.backspace();
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
-      expect(editorElement.querySelectorAll('.git-line-modified').length).toBe(
-        0
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-line-modified').length
+        ).toBe(1);
+        editor.backspace();
+        advanceClock(editor.getBuffer().stoppedChangingDelay);
+      });
+      waitsFor(
+        () => editorElement.querySelectorAll('.git-line-modified').length < 1
       );
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-line-modified').length
+        ).toBe(0);
+      });
     });
   });
 
@@ -119,21 +159,17 @@ describe('GitDiff package', () => {
         path.join(projectPath, 'sample.txt'),
         'Some different text.'
       );
-      let nextTick = false;
 
       waitsForPromise(() =>
         atom.workspace.open(path.join(projectPath, 'sample.txt'))
       );
 
       runs(() => {
-        editorElement = atom.workspace.getActiveTextEditor().getElement();
+        editor = atom.workspace.getActiveTextEditor();
+        editorElement = editor.getElement();
       });
 
-      setImmediate(() => {
-        nextTick = true;
-      });
-
-      waitsFor(() => nextTick);
+      waitsFor(() => editor.getMarkers().length > 0);
 
       runs(() => {
         expect(
@@ -152,39 +188,49 @@ describe('GitDiff package', () => {
       editor.deleteLine();
       atom.project.setPaths([temp.mkdirSync('no-repository')]);
       advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(() => editor.getMarkers().length === 0);
+      runs(() => {
+        expect(editor.getMarkers().length).toBe(0);
+      });
     });
   });
 
   describe('move-to-next-diff/move-to-previous-diff events', () => {
     it('moves the cursor to first character of the next/previous diff line', () => {
       editor.insertText('a');
-      editor.setCursorBufferPosition([5]);
-      editor.deleteLine();
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        editor.setCursorBufferPosition([5]);
+        editor.deleteLine();
+        advanceClock(editor.getBuffer().stoppedChangingDelay);
 
-      editor.setCursorBufferPosition([0]);
-      atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-      expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+        editor.setCursorBufferPosition([0]);
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
 
-      atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
-      expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
+        expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+      });
     });
 
     it('wraps around to the first/last diff in the file', () => {
       editor.insertText('a');
-      editor.setCursorBufferPosition([5]);
-      editor.deleteLine();
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        editor.setCursorBufferPosition([5]);
+        editor.deleteLine();
+        advanceClock(editor.getBuffer().stoppedChangingDelay);
 
-      editor.setCursorBufferPosition([0]);
-      atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-      expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+        editor.setCursorBufferPosition([0]);
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
 
-      atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-      expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        expect(editor.getCursorBufferPosition().toArray()).toEqual([0, 0]);
 
-      atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
-      expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
+        expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
+      });
     });
 
     describe('when the wrapAroundOnMoveToDiff config option is false', () => {
@@ -197,19 +243,28 @@ describe('GitDiff package', () => {
         editor.setCursorBufferPosition([5]);
         editor.deleteLine();
         advanceClock(editor.getBuffer().stoppedChangingDelay);
+        waitsFor(() => editor.getMarkers().length > 0);
 
-        editor.setCursorBufferPosition([0]);
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-        expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+        runs(() => {
+          editor.setCursorBufferPosition([0]);
+          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+          expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
 
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-        expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+          expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
 
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
-        expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+          atom.commands.dispatch(
+            editorElement,
+            'git-diff:move-to-previous-diff'
+          );
+          expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
 
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
-        expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+          atom.commands.dispatch(
+            editorElement,
+            'git-diff:move-to-previous-diff'
+          );
+          expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+        });
       });
     });
   });
@@ -219,28 +274,40 @@ describe('GitDiff package', () => {
       atom.config.set('git-diff.showIconsInEditorGutter', true);
     });
 
-    it('the gutter has a git-diff-icon class', () =>
-      expect(editorElement.querySelector('.gutter')).toHaveClass(
-        'git-diff-icon'
-      ));
+    it('the gutter has a git-diff-icon class', () => {
+      waitsFor(() => screenUpdates > 0);
+      runs(() => {
+        expect(editorElement.querySelector('.gutter')).toHaveClass(
+          'git-diff-icon'
+        );
+      });
+    });
 
     it('keeps the git-diff-icon class when editor.showLineNumbers is toggled', () => {
-      atom.config.set('editor.showLineNumbers', false);
-      expect(editorElement.querySelector('.gutter')).not.toHaveClass(
-        'git-diff-icon'
-      );
+      waitsFor(() => screenUpdates > 0);
 
-      atom.config.set('editor.showLineNumbers', true);
-      expect(editorElement.querySelector('.gutter')).toHaveClass(
-        'git-diff-icon'
-      );
+      runs(() => {
+        atom.config.set('editor.showLineNumbers', false);
+        expect(editorElement.querySelector('.gutter')).not.toHaveClass(
+          'git-diff-icon'
+        );
+
+        atom.config.set('editor.showLineNumbers', true);
+        expect(editorElement.querySelector('.gutter')).toHaveClass(
+          'git-diff-icon'
+        );
+      });
     });
 
     it('removes the git-diff-icon class when the showIconsInEditorGutter config option set to false', () => {
-      atom.config.set('git-diff.showIconsInEditorGutter', false);
-      expect(editorElement.querySelector('.gutter')).not.toHaveClass(
-        'git-diff-icon'
-      );
+      waitsFor(() => screenUpdates > 0);
+
+      runs(() => {
+        atom.config.set('git-diff.showIconsInEditorGutter', false);
+        expect(editorElement.querySelector('.gutter')).not.toHaveClass(
+          'git-diff-icon'
+        );
+      });
     });
   });
 });

--- a/packages/git-diff/spec/git-diff-spec.js
+++ b/packages/git-diff/spec/git-diff-spec.js
@@ -7,11 +7,11 @@ describe('GitDiff package', () => {
 
   beforeEach(() => {
     screenUpdates = 0;
-    spyOn(window, 'requestAnimationFrame').andCallFake((fn) => {
+    spyOn(window, 'requestAnimationFrame').andCallFake(fn => {
       fn();
       screenUpdates++;
     });
-    spyOn(window, 'cancelAnimationFrame').andCallFake((i) => null);
+    spyOn(window, 'cancelAnimationFrame').andCallFake(i => null);
 
     projectPath = temp.mkdirSync('git-diff-spec-');
     const otherPath = temp.mkdirSync('some-other-path-');

--- a/packages/git-diff/spec/git-diff-spec.js
+++ b/packages/git-diff/spec/git-diff-spec.js
@@ -1,12 +1,12 @@
 const path = require('path');
 const fs = require('fs-plus');
-const temp = require('temp');
+const temp = require('temp').track();
 
 describe('GitDiff package', () => {
   let editor, editorElement, projectPath;
 
   beforeEach(() => {
-    spyOn(window, 'setImmediate').andCallFake(fn => fn());
+    spyOn(window, 'setImmediate').andCallFake((fn) => fn());
 
     projectPath = temp.mkdirSync('git-diff-spec-');
     const otherPath = temp.mkdirSync('some-other-path-');

--- a/packages/git-diff/spec/init-spec.js
+++ b/packages/git-diff/spec/init-spec.js
@@ -5,7 +5,7 @@ const temp = require('temp').track();
 const commands = [
   'git-diff:toggle-diff-list',
   'git-diff:move-to-next-diff',
-  'git-diff:move-to-previous-diff',
+  'git-diff:move-to-previous-diff'
 ];
 
 describe('git-diff', () => {
@@ -41,7 +41,7 @@ describe('git-diff', () => {
         atom.commands
           .findCommands({ target: element })
           .filter(({ name }) => commands.includes(name))
-          .forEach((command) => expect(commands).not.toContain(command.name));
+          .forEach(command => expect(commands).not.toContain(command.name));
       });
     });
   });

--- a/packages/git-diff/spec/init-spec.js
+++ b/packages/git-diff/spec/init-spec.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const fs = require('fs-plus');
+const temp = require('temp').track();
+
+const commands = [
+  'git-diff:toggle-diff-list',
+  'git-diff:move-to-next-diff',
+  'git-diff:move-to-previous-diff',
+];
+
+describe('git-diff', () => {
+  let editor, element;
+
+  beforeEach(() => {
+    const projectPath = temp.mkdirSync('git-diff-spec-');
+    fs.copySync(path.join(__dirname, 'fixtures', 'working-dir'), projectPath);
+    fs.moveSync(
+      path.join(projectPath, 'git.git'),
+      path.join(projectPath, '.git')
+    );
+    atom.project.setPaths([projectPath]);
+
+    jasmine.attachToDOM(atom.workspace.getElement());
+
+    waitsForPromise(() => atom.workspace.open('sample.js'));
+
+    runs(() => {
+      editor = atom.workspace.getActiveTextEditor();
+      element = atom.views.getView(editor);
+    });
+  });
+
+  it('Removes all registered command hooks after deactivation.', () => {
+    waitsForPromise(() => atom.packages.activatePackage('git-diff'));
+    waitsForPromise(() => atom.packages.deactivatePackage('git-diff'));
+    runs(() => {
+      // NOTE: don't use enable and disable from the Public API.
+      expect(atom.packages.isPackageActive('git-diff')).toBe(false);
+
+      atom.commands
+        .findCommands({ target: element })
+        .filter(({ name }) => commands.includes(name))
+        .forEach((command) => expect(commands).not.toContain(command.name));
+    });
+  });
+});

--- a/packages/git-diff/spec/init-spec.js
+++ b/packages/git-diff/spec/init-spec.js
@@ -30,17 +30,19 @@ describe('git-diff', () => {
     });
   });
 
-  it('Removes all registered command hooks after deactivation.', () => {
-    waitsForPromise(() => atom.packages.activatePackage('git-diff'));
-    waitsForPromise(() => atom.packages.deactivatePackage('git-diff'));
-    runs(() => {
-      // NOTE: don't use enable and disable from the Public API.
-      expect(atom.packages.isPackageActive('git-diff')).toBe(false);
+  describe('When the module is deactivated', () => {
+    it('removes all registered command hooks after deactivation.', () => {
+      waitsForPromise(() => atom.packages.activatePackage('git-diff'));
+      waitsForPromise(() => atom.packages.deactivatePackage('git-diff'));
+      runs(() => {
+        // NOTE: don't use enable and disable from the Public API.
+        expect(atom.packages.isPackageActive('git-diff')).toBe(false);
 
-      atom.commands
-        .findCommands({ target: element })
-        .filter(({ name }) => commands.includes(name))
-        .forEach((command) => expect(commands).not.toContain(command.name));
+        atom.commands
+          .findCommands({ target: element })
+          .filter(({ name }) => commands.includes(name))
+          .forEach((command) => expect(commands).not.toContain(command.name));
+      });
     });
   });
 });


### PR DESCRIPTION
### Identify the Bug
Was intended to fix bug #21966 but also fixes #21967

### Description of the Change
The startup script now uses a `Set` to manage `GitDiffView`s held in memory and destroy them when `deactivate` is called.
There are now four major subscription blocks. 
1. The outer subscriptions held by `activate`.
2. The per-editor subscriptions held within `activate`.
3. The per-editor repository event subscriptions held within each `GitDIffView` instance.
4. The per-editor modification event subscriptions held within each `GitDiffView` which are only active when the editor content is bound to avalid git repository.

Teardowns of any editor or the module now result in `dispose`al of the respective editor's subscriptions or all subscriptions authored within the module.

I removed some of `GitDiffView`'s unnecessary methods such as the `start`, `cancleUpdate`, `addDecoration` and `removeDecorations`;
The last two methods were combined into the body of `updateDiffs`.
`scheduleUpdate` now calls `requestAnimationFrame` instead of `setImmediate` because it's native, standard, and yields
to other more important browser processes. I know Atom Core implements setImmediate, but rAF seems to work just as fast if not faster.
The memory management of the editor markers and diffs have been joined using a WeakMap. When the diffs are destroyed,
so too are the editor markers.
Finally, I added the `destroy` method to handle teardown of subscriptions and other destroyable objects contained within the `GitDiffViews` before object release.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

I considered doing everything from within the main `activate` function, but decided against it because it's far more concise to put a lot of the functionality contained herein, into a single object.

### Possible Drawbacks

There's a warning in the source now; If the API for `git-utils` ever decides to re-use diff symbols between `repository.getLineDiffs` fetches, it could cause a memory leak due to my use of the `WeakMap` for allocation performance.


### Verification Process

I had to rewrite most of the existing specs to accomidate the async screen updates. I also added a test case to prevent regression of issue #21966. Beyond that, I tested modifying code and deleting lines, adding lines while in newly opened editors and turning the module on and off again between doing so.

I also check the Chromium memory profiler for leaks.
[Here's my heapprofile while flopping between the module on and off](https://drive.google.com/file/d/1T4pj5q5tM6LKe1_nAQ6tPqk6RJn41CJ7/view?usp=sharing),
[And here's the heapsnapshot sans forced garbage collection](https://drive.google.com/file/d/1DIX2grbiCgvyXIrzrIH3QzLfgmIlL9Ap/view?usp=sharing)

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
 - Git Diff commands no longer accumulate when turning the package on and off.
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
