### PR TITLE
Add libxkbfile.so.1 to RPM Requires

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -8,9 +8,9 @@ AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
 %ifarch i386 i486 i586 i686
-Requires: lsb-core-noarch, libXss.so.1 libsecret-1.so.0, polkit
+Requires: lsb-core-noarch, libxkbfile.so.1, libXss.so.1, libsecret-1.so.0, polkit
 %else
-Requires: lsb-core-noarch, libXss.so.1()(64bit) libsecret-1.so.0()(64bit), polkit
+Requires: lsb-core-noarch, libxkbfile.so.1()(64bit), libXss.so.1()(64bit), libsecret-1.so.0()(64bit), polkit
 %endif
 
 # Disable Fedora's shebang mangling script,


### PR DESCRIPTION
Fix #21238

RPM also needs a requires `libxkbfile` statement
