### PR TITLE
Clang 9 is already in the image.

### DIFF
--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -6,10 +6,6 @@ steps:
       sudo apt-get install -y wget software-properties-common
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0 libasound2 libicu-dev
       # clang 9 is included in the image
-      sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 10
-      sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 10
-      sudo update-alternatives --config clang
-      sudo update-alternatives --config clang++
       clang -v
     displayName: Install apt dependencies
     condition: eq(variables['Agent.OS'], 'Linux')


### PR DESCRIPTION

Clang 9 is on the `PATH` and is the version that will be used without needing to do update-alternatives.