### PR TITLE
Don't merge, just a test: Electron to 11.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "9.4.4",
+  "electronVersion": "11.3.0",
   "dependencies": {
     "@atom/fuzzy-native": "^1.2.0",
     "@atom/nsfw": "^1.0.27",


### PR DESCRIPTION
Is same npm major version, and no breaking changes according to electron docs.

Let's see if upgrade path would be easy, and getting back to supported electron versions (support for electron 9 has just been dropped when we finally got to it...)