### PR TITLE
Update required dependencies for Debian/Ubuntu

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,7 +1,7 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgcrypt20, libgtk-3-0 (>= 3.9.10), libnotify4, libnss3 (>= 2:3.22), libglib2.0-bin | kde-cli-tools | kde-runtime, xdg-utils, libx11-xcb1, libxcb-dri3-0, libxss1, libxtst6, libxkbfile1, libcurl3 | libcurl4
-Recommends: libasound2 (>= 1.0.16), policykit-1, libsecret-1-0, gnome-keyring
+Depends: git, libgcrypt20, libgtk-3-0 (>= 3.9.10), libnotify4, libnss3 (>= 2:3.22), libglib2.0-bin | kde-cli-tools | kde-runtime, xdg-utils, libasound2 (>= 1.0.16), libgbm1, libx11-xcb1, libxcb-dri3-0, libxss1, libxtst6, libxkbfile1, libcurl3 | libcurl4
+Recommends: policykit-1, libsecret-1-0, gnome-keyring
 Suggests: lsb-release
 Section: devel
 Priority: optional

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), libglib2.0-bin | kde-cli-tools | kde-runtime, xdg-utils, libx11-xcb1, libxss1, libxkbfile1, libcurl3 | libcurl4
+Depends: git, libgcrypt20, libgtk-3-0 (>= 3.9.10), libnotify4, libnss3 (>= 2:3.22), libglib2.0-bin | kde-cli-tools | kde-runtime, xdg-utils, libx11-xcb1, libxcb-dri3-0, libxss1, libxtst6, libxkbfile1, libcurl3 | libcurl4
 Recommends: libasound2 (>= 1.0.16), policykit-1, libsecret-1-0, gnome-keyring
 Suggests: lsb-release
 Section: devel


### PR DESCRIPTION
After trying to build Atom on a very bare Ubuntu install, I figured out some missing dependencies for building: https://github.com/atom/flight-manual.atom.io/pull/683

That also implied these libraries are the actual correct dependencies
