### PR TITLE
Fix typo in menu-sort-helpers-spec.js

### DIFF
--- a/spec/menu-sort-helpers-spec.js
+++ b/spec/menu-sort-helpers-spec.js
@@ -15,7 +15,7 @@ describe('contextMenu', () => {
       expect(sortMenuItems(items)).toEqual(expected);
     });
 
-    it('preserves separators at the begining of set two', () => {
+    it('preserves separators at the beginning of set two', () => {
       const items = [
         { command: 'core:one' },
         { type: 'separator' },


### PR DESCRIPTION
### Description of the Change

`begining` -> `beginning`
