### PR TITLE
Fix: remove unused parser instance

### DIFF
--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -31,7 +31,6 @@ class TreeSitterLanguageMode {
     this.grammar = grammar;
     this.config = config;
     this.grammarRegistry = grammars;
-    this.parser = new Parser();
     this.rootLanguageLayer = new LanguageLayer(null, this, grammar, 0);
     this.injectionsMarkerLayer = buffer.addMarkerLayer();
 
@@ -79,7 +78,6 @@ class TreeSitterLanguageMode {
   destroy() {
     this.injectionsMarkerLayer.destroy();
     this.rootLanguageLayer = null;
-    this.parser = null;
   }
 
   getLanguageId() {


### PR DESCRIPTION
Hello, this is really trivial and also I'm not using Atom, I just happened to be reading the code, so I'll forgo the bugfix template and make it short, please close if you're not interested:

## Issue

In tree-sitter-language-mode.js, each instance of the TreeSitterLanguageMode creates a new tree-sitter Parser in its constructor. This parser instance is never used because the `.parse()` function uses a parse instance from the `PARSER_POOL` array.

## Solution

Don't create an unused instance.

## References

https://github.com/atom/atom/blob/757478442696b302bb8f9ad16e93b30f9350d949/src/tree-sitter-language-mode.js#L34

https://github.com/atom/atom/blob/757478442696b302bb8f9ad16e93b30f9350d949/src/tree-sitter-language-mode.js#L116-L133
