### PR TITLE
utils.less: Update comment to reflect final PR wording

### DIFF
--- a/static/core-ui/utils.less
+++ b/static/core-ui/utils.less
@@ -1,6 +1,6 @@
 
 // CSS containment variables.
-// The words after `but` explicitly show the excluded/incompatible values.
+// The words after `except` explicitly show the excluded/incompatible values.
 @contain_all: layout size paint style;
 @contain_except_layout: size paint style;
 @contain_except_size: layout paint style;


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.

### Description of the Change

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

Update a comment to match the variables it describes.

Details:

This file includes some convenience variables, each holding a set of values for the [CSS `contain` property](https://developer.mozilla.org/en-US/docs/Web/CSS/contain). 

The comment in this file mentions that all the variables use a naming scheme with a `but` keyword to indicate which values of the [CSS `contain` property](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) are excluded.

During the discussion and review of [the PR that added this file](https://github.com/atom/atom/pull/21561), it was [decided](https://github.com/atom/atom/pull/21561#discussion_r559887435) to change `but` to `except`. So I'm updating the comment to match the variable names that were changed.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A