### PR TITLE
Fix tree-sitter-language-mode null highlight iterators

### DIFF
--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -145,7 +145,7 @@ class TreeSitterLanguageMode {
   */
 
   buildHighlightIterator() {
-    if (!this.rootLanguageLayer) return new NullHighlightIterator();
+    if (!this.rootLanguageLayer) return new NullLanguageModeHighlightIterator();
     return new HighlightIterator(this);
   }
 
@@ -651,7 +651,7 @@ class LanguageLayer {
     if (this.tree) {
       return new LayerHighlightIterator(this, this.tree.walk());
     } else {
-      return new NullHighlightIterator();
+      return new NullLayerHighlightIterator();
     }
   }
 
@@ -1337,7 +1337,26 @@ class NodeCursorAdaptor {
   }
 }
 
-class NullHighlightIterator {
+class NullLanguageModeHighlightIterator {
+  seek() {
+    return [];
+  }
+  compare() {
+    return 1;
+  }
+  moveToSuccessor() {}
+  getPosition() {
+    return Point.INFINITY;
+  }
+  getOpenScopeIds() {
+    return [];
+  }
+  getCloseScopeIds() {
+    return [];
+  }
+}
+
+class NullLayerHighlightIterator {
   seek() {
     return null;
   }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

https://github.com/atom/atom/issues/22078

### Description of the Change

There are two types of highlight iterators in the file -- one for the LanguageMode, where `seek` method returns an array, and one for Layer, which returns a boolean(-ish). Both used `NullHighlightIterator` on occasion, which led to some breakage: one instance was fixed in https://github.com/atom/atom/pull/21753, however that in itself created https://github.com/atom/atom/issues/22078. This PR disambiguates the two kinds of iterators and uses a separate class in place of `NullHighlightIterator` where appropriate.

### Alternate Designs

An alternative approach is making both kinds of iterators conform to a single interface, i.e. for `seek` to either return an array or a boolean. However, that is much more involved and probably entails a complete rewrite of some parts of the code. I do not understand the code well enough to attempt this, and I don't really have the time to do it either.

### Possible Drawbacks

One obvious drawback is some minor code duplication. I'm on the fence about this.

On one hand, there is apparent code duplication. On another hand, null iterators mimic non-null iterators structurally (i.e. both null and non-null iterators use separate implementations). Non-null iterators behave very differently and share very little code beyond method names. Null iterators are pretty similar to each other however, but arguably that's a coincidence, and a shared implementation is what basically caused #22078 in the first place.

Overall, I'm leaning to "there's not so much code duplication as to really worry about it, and there are potential drawbacks to reducing it".

### Verification Process

I've stared at the code for about half an hour. That was about enough to understand something is horribly wrong there. ~~No tests were performed as of the time of the writing, but I'm pretty confident in the results (the issue is pretty obvious to begin with). If/when the tests are performed, I will update this text.~~

@aminya [ran CI](https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=1058&view=results), one unrelated test failed on Windows due to a timeout, and prettier complains about some formatting on line 1544, which is not touched in this PR. He also [verified](https://github.com/atom/atom/pull/22080#pullrequestreview-619955276) that #22078 is indeed fixed by this PR.

### Release Notes

N/A, this issue at present manifests only in v1.56.0-beta0 and up.

### Notice

~~:warning::rotating_light::warning::rotating_light::warning::rotating_light::warning: This should be backported to v1.56 branch. Since the code didn't change at all between v1.56 and master, the backport should be very straightforward. I can make a PR against 1.56-releases branch if that would be suitable.~~ #22085 is merged