### PR TITLE
Fix tree-sitter-language-mode null highlight iterators (Atom 1.56 backport)

### DIFF
--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -145,7 +145,7 @@ class TreeSitterLanguageMode {
   */
 
   buildHighlightIterator() {
-    if (!this.rootLanguageLayer) return new NullHighlightIterator();
+    if (!this.rootLanguageLayer) return new NullLanguageModeHighlightIterator();
     return new HighlightIterator(this);
   }
 
@@ -651,7 +651,7 @@ class LanguageLayer {
     if (this.tree) {
       return new LayerHighlightIterator(this, this.tree.walk());
     } else {
-      return new NullHighlightIterator();
+      return new NullLayerHighlightIterator();
     }
   }
 
@@ -1337,7 +1337,26 @@ class NodeCursorAdaptor {
   }
 }
 
-class NullHighlightIterator {
+class NullLanguageModeHighlightIterator {
+  seek() {
+    return [];
+  }
+  compare() {
+    return 1;
+  }
+  moveToSuccessor() {}
+  getPosition() {
+    return Point.INFINITY;
+  }
+  getOpenScopeIds() {
+    return [];
+  }
+  getCloseScopeIds() {
+    return [];
+  }
+}
+
+class NullLayerHighlightIterator {
   seek() {
     return null;
   }


### PR DESCRIPTION
This is a backport of #22080 to 1.56-releases.