### PR TITLE
Ubuntu 18.04 upgrade for CI

### DIFF
--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -5,7 +5,7 @@ jobs:
     variables:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
 
     steps:
       - template: templates/preparation.yml


### PR DESCRIPTION
Ubuntu 16.04 is not supported anymore.

Ubuntu 18.04 is necessary to resolve #22076 because we require a more up-to-date `rpmbuild`