### PR TITLE
Get rpm from bionic

### DIFF
--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -7,7 +7,7 @@ steps:
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
       # rpm needs to be at least 4.14, in xenial it is too old
       sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
-      sudo apt update
+      sudo apt-get update
       sudo apt-get install -y rpm
       # clang 9 is included in the image
       clang -v

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -6,6 +6,7 @@ steps:
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common wget
       # rpm needs to be at least 4.14, in xenial it is too old
       sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
+      sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic-security main universe'
       sudo apt-get update
       sudo apt-get install -y rpm
       # clang 9 is included in the image

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -6,7 +6,7 @@ steps:
       sudo apt-get install -y wget software-properties-common
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
       # rpm needs to be at least 4.14, in xenial it is too old
-      sudo apt-add-repository -y ‘deb https://azure.archive.ubuntu.com/ubuntu/ bionic main universe’
+      sudo apt-add-repository -y 'deb https://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
       sudo apt update
       sudo apt-get install -y rpm
       # clang 9 is included in the image

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -3,8 +3,7 @@ steps:
   # Linux Specific
   - script: |
       sudo apt-get update
-      sudo apt-get install -y wget software-properties-common
-      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
+      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common wget
       # rpm needs to be at least 4.14, in xenial it is too old
       sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
       sudo apt-get update

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -6,7 +6,7 @@ steps:
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common wget
       # rpm needs to be at least 4.14, in xenial it is too old
       sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
-      sudo apt-add-repository -y 'deb https://esm.ubuntu.com/infra/ubuntu bionic-infra-security main universe'
+      sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic-security main universe'
       sudo apt-get update
       sudo apt-get install -y rpm
       # clang 9 is included in the image

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -4,7 +4,10 @@ steps:
   - script: |
       sudo apt-get update
       sudo apt-get install -y wget software-properties-common
-      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev
+      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-devlibx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
+      # rpm needs to be at least 4.14, in xenial it is too old
+      sudo apt-add-repository -y ‘deb https://archive.ubuntu.com/ubuntu/ bionic main universe’
+      sudo apt-get install -y rpm
       # clang 9 is included in the image
       clang -v
     displayName: Install apt dependencies

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -6,7 +6,7 @@ steps:
       sudo apt-get install -y wget software-properties-common
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-devlibx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
       # rpm needs to be at least 4.14, in xenial it is too old
-      sudo apt-add-repository -y ‘deb https://archive.ubuntu.com/ubuntu/ bionic main universe’
+      sudo apt-add-repository -y ‘deb https://azure.archive.ubuntu.com/ubuntu/ bionic main universe’
       sudo apt-get install -y rpm
       # clang 9 is included in the image
       clang -v

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -6,7 +6,7 @@ steps:
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common wget
       # rpm needs to be at least 4.14, in xenial it is too old
       sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
-      sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic-security main universe'
+      sudo apt-add-repository -y 'deb https://esm.ubuntu.com/infra/ubuntu bionic-infra-security main universe'
       sudo apt-get update
       sudo apt-get install -y rpm
       # clang 9 is included in the image

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -4,9 +4,10 @@ steps:
   - script: |
       sudo apt-get update
       sudo apt-get install -y wget software-properties-common
-      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-devlibx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
+      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
       # rpm needs to be at least 4.14, in xenial it is too old
       sudo apt-add-repository -y ‘deb https://azure.archive.ubuntu.com/ubuntu/ bionic main universe’
+      sudo apt update
       sudo apt-get install -y rpm
       # clang 9 is included in the image
       clang -v

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -4,7 +4,7 @@ steps:
   - script: |
       sudo apt-get update
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common wget
-      # rpm needs to be at least 4.14, in xenial it is too old
+      # rpm needs to be at least 4.13, in xenial it is too old
       sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
       sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic-security main universe'
       sudo apt-get update

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -6,7 +6,7 @@ steps:
       sudo apt-get install -y wget software-properties-common
       sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev software-properties-common
       # rpm needs to be at least 4.14, in xenial it is too old
-      sudo apt-add-repository -y 'deb https://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
+      sudo apt-add-repository -y 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main universe'
       sudo apt update
       sudo apt-get install -y rpm
       # clang 9 is included in the image


### PR DESCRIPTION
Instead of upgrading completely to bionic as in #22416
because of possible glibc issues with older releases, limit the upgrade to bionic for just `rpm`

`software-properties-common` is added as earlier dependency in the script, because it contains the `apt-add-repository` command, so we need to be sure it is in place before adding the bionic repository.