### PR TITLE
script: Let bootstrap install `apm` with `npm ci`

### DIFF
--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -5,11 +5,15 @@ const childProcess = require('child_process');
 const CONFIG = require('../config');
 
 module.exports = function(ci) {
+  if (ci) {
+    // Tell apm not to dedupe its own dependencies during its
+    // postinstall script. (Deduping during `npm ci` runs is broken.)
+    process.env.NO_APM_DEDUPE = 'true';
+  }
   console.log('Installing apm');
-  // npm ci leaves apm with a bunch of unmet dependencies
   childProcess.execFileSync(
     CONFIG.getNpmBinPath(),
-    ['--global-style', '--loglevel=error', 'install'],
+    ['--global-style', '--loglevel=error', ci ? 'ci' : 'install'],
     { env: process.env, cwd: CONFIG.apmRootPath }
   );
 };


### PR DESCRIPTION
<details><summary>Requirements for Adding, Changing, or Removing a Feature (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Issue or RFC Endorsed by Atom's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

None, but takes advantage of a PR at `apm` that was approved by maintainers: https://github.com/atom/apm/pull/912

### Description of the Change

<!--


We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When bootstrapping/building Atom in `ci` mode, set `NO_APM_DEDUPE="true"` and install `apm` with `npm ci` (rather than `npm install`).

This enables faster, more-reproducible installs of `apm`, much like we already do for the `scripts/` dependencies and the core Atom dependencies.

This only affects bootstrapping/building Atom; This should not make any difference to the built Atom app _(except ensuring `apm`'s dependencies are pinned to exact versions)_, and should not make any difference to `apm`'s behavior as a command-line tool/as a component of Atom.

<details>

As of apm 2.6.2, apm respects a `NO_APM_DEDUPE` env var on Windows.
(It was already supported on Linux and macOS before then.)
When set, this env var disables the deduping
normally performed at the end of apm's postinstall script.

This deduping doesn't work properly when installing apm with `npm ci`,
for unknown reasons. (The deduping algorithm deletes many needed
dependencies, without reconstructing a valid tree.)

Now that `apm` supports `NO_APM_DEDUPE` on all platforms,
we can safely allow installing `apm` with `npm ci`
during the bootstrap script.

Now bootstrapping apm in `ci` mode is faster in two ways:
- `npm ci` is generally faster than `npm install` for clean installs.
  - Great for actual automated builds ("CI").
- The `npm dedupe` run is now skipped in `ci` mode.
  - The `npm dedupe` was of dubious value in any case
  - The `npm dedupe` command was also surprisingly slow

We also benefit from the stronger reproducibility of `npm ci`
compared to `npm install` (guaranteed, version-locked dependencies).

</details>

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

At the community fork of `apm`, we opted to delete deduping from `apm`'s `postinstall` script altogether, so the `NO_APM_DEDUPE` env var isn't needed.

See: https://github.com/atom-community/apm/pull/71

That can be done at the official `apm` repo too, if desired, but it could even be done after this PR. It need not block this PR.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Ran `script/bootstrap --ci` and `script/build --ci` locally with this change.

Result: No broken/missing packages, and the "Installing apm" step of bootstrapping went a bit faster (because `npm ci` is faster than `npm install` for clean installs, and because it didn't spend any time deduping).

Ran this branch in Azure Pipelines.

Result: CI passed. https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1127&view=results

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
N/A