### PR TITLE
Document TextEditor::bufferRangeForScopeAtBufferPosition 

### DIFF
--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4588,8 +4588,10 @@ module.exports = class TextEditor {
   // * `bufferPosition` A {Point} or {Array} of [row, column]
   //
   // Returns a {Range}.
-  bufferRangeForScopeAtPosition (scopeSelector, bufferPosition) {
-    return this.buffer.getLanguageMode().bufferRangeForScopeAtPosition(scopeSelector, bufferPosition)
+  bufferRangeForScopeAtPosition(scopeSelector, bufferPosition) {
+    return this.buffer
+      .getLanguageMode()
+      .bufferRangeForScopeAtPosition(scopeSelector, bufferPosition);
   }
 
   // Extended: Determine if the given row is entirely a comment

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4582,13 +4582,13 @@ module.exports = class TextEditor {
   // given position in buffer coordinates that match the given scope selector.
   //
   // For example, if you wanted to find the string surrounding the cursor, you
-  // could call `editor.bufferRangeForScopeAtBufferPosition(".string.quoted", this.getCursorBufferPosition())`.
+  // could call `editor.bufferRangeForScopeAtPosition(".string.quoted", this.getCursorBufferPosition())`.
   //
   // * `scopeSelector` {String} selector. e.g. `'.source.ruby'`
   // * `bufferPosition` A {Point} or {Array} of [row, column]
   //
   // Returns a {Range}.
-  bufferRangeForScopeAtBufferPosition (scopeSelector, bufferPosition) {
+  bufferRangeForScopeAtPosition (scopeSelector, bufferPosition) {
     return this.buffer.getLanguageMode().bufferRangeForScopeAtPosition(scopeSelector, bufferPosition)
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4577,11 +4577,19 @@ module.exports = class TextEditor {
       this.getCursorBufferPosition()
     );
   }
-
-  bufferRangeForScopeAtPosition(scopeSelector, position) {
-    return this.buffer
-      .getLanguageMode()
-      .bufferRangeForScopeAtPosition(scopeSelector, position);
+  
+  // Extended: Get the range in buffer coordinates of all tokens surrounding the
+  // given position in buffer coordinates that match the given scope selector.
+  //
+  // For example, if you wanted to find the string surrounding the cursor, you
+  // could call `editor.bufferRangeForScopeAtBufferPosition(".string.quoted", this.getCursorBufferPosition())`.
+  //
+  // * `scopeSelector` {String} selector. e.g. `'.source.ruby'`
+  // * `bufferPosition` A {Point} or {Array} of [row, column]
+  //
+  // Returns a {Range}.
+  bufferRangeForScopeAtBufferPosition (scopeSelector, bufferPosition) {
+    return this.buffer.getLanguageMode().bufferRangeForScopeAtPosition(scopeSelector, bufferPosition)
   }
 
   // Extended: Determine if the given row is entirely a comment

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4577,7 +4577,7 @@ module.exports = class TextEditor {
       this.getCursorBufferPosition()
     );
   }
-  
+
   // Extended: Get the range in buffer coordinates of all tokens surrounding the
   // given position in buffer coordinates that match the given scope selector.
   //


### PR DESCRIPTION
### Description of the Change

It seemed odd for `bufferRangeForScopeAtCursor` to exist without `bufferRangeForScopeAtBufferPosition` existing, so that one could (e.g.) handle multiple cursors.
`bufferRangeForScopeAtPosition` already existed (used by `bufferRangeForScopeAtCursor`). When I went to add docs I noticed that the other public methods of `TextEditor` used a particular naming scheme, so I also changed the name to "bufferRangeForScopeAtBufferPosition" to match.

### Alternate Designs

N/A

### Why Should This Be In Core?

Super handy for figuring out scopes from a package. And has more possible uses than the existing `bufferRangeForScopeAtCursor`.

### Benefits

Ditto.

### Possible Drawbacks

If a package were using this undocumented API then it would break.
I could leave "bufferRangeForScopeAtPosition" in as an undocumented alias if that's a concern.

### Verification Process

It's really just docs. Let me know what you'd like.

### Applicable Issues

N/A