### PR TITLE
Change "File uses the *x* grammar" to "File uses *x* syntax"

### DIFF
--- a/packages/grammar-selector/lib/grammar-status-view.js
+++ b/packages/grammar-selector/lib/grammar-status-view.js
@@ -104,7 +104,7 @@ module.exports = class GrammarStatusView {
         this.element.style.display = '';
 
         this.tooltip = atom.tooltips.add(this.element, {
-          title: `File uses the ${grammarName} grammar`
+          title: `File uses the ${grammarName} syntax`
         });
       } else {
         this.element.style.display = 'none';


### PR DESCRIPTION
I've gone ahead and made a pr for #22471

Resolves #22471
Alternatively there could also be a comment explaining why `grammarName` is now called a `syntax`, but for now that comment doesn't exist.
