### PR TITLE
git-diff: Fix typo in code

### DIFF
--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -104,7 +104,7 @@ export default class GitDiffView {
         }),
         this.editor.onDidStopChanging(scheduleUpdate),
         this.editor.onDidChangePath(() => {
-          this.editorPath = this.edtior.getPath();
+          this.editorPath = this.editor.getPath();
           this.buffer = this.editor.getBuffer();
           scheduleUpdate();
         }),


### PR DESCRIPTION
### Identify the Bug

- Fixes #22542.
- Fixes #22532.

### Description of the Change

A typo inside the function `subscribeToRepository` was causing the mentioned TypeError because the variable `this.edtior` was undefined. Changing it to `this.editor` fixes the error.

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

After this change, `subscribeToRepository` no longer throws an error when called, e.g. when following the steps to reproduce the issue.

### Release Notes

- Fixed a typo in the git-diff package that causes repository subscriptions to fail.