### PR TITLE
tree-indenter: Fix typo

### DIFF
--- a/src/tree-indenter.js
+++ b/src/tree-indenter.js
@@ -76,7 +76,7 @@ module.exports = class TreeIndenter {
       this.scopes.types.outdent[node.type] && increment && typeDent--;
       increment += typeDent;
 
-      // check whether the last (lower) indentation happend due to a scope that
+      // check whether the last (lower) indentation happened due to a scope that
       // started on the same row and ends directly before this.
       if (
         lastScope &&


### PR DESCRIPTION

### Description of the Change

`happend` -> `happened`