### PR TITLE
Fix/not update menu with i18n (#22594)

### DIFF
--- a/spec/context-menu-manager-spec.js
+++ b/spec/context-menu-manager-spec.js
@@ -1,519 +1,500 @@
-const ContextMenuManager = require('../src/context-menu-manager');
+const ContextMenuManager = require("../src/context-menu-manager")
 
-describe('ContextMenuManager', function() {
-  let [contextMenu, parent, child, grandchild] = [];
+describe("ContextMenuManager", function () {
+  let [contextMenu, parent, child, grandchild] = []
 
-  beforeEach(function() {
-    const { resourcePath } = atom.getLoadSettings();
-    contextMenu = new ContextMenuManager({ keymapManager: atom.keymaps });
-    contextMenu.initialize({ resourcePath });
+  beforeEach(function () {
+    const {resourcePath} = atom.getLoadSettings()
+    contextMenu = new ContextMenuManager({keymapManager: atom.keymaps})
+    contextMenu.initialize({resourcePath})
 
-    parent = document.createElement('div');
-    child = document.createElement('div');
-    grandchild = document.createElement('div');
-    parent.tabIndex = -1;
-    child.tabIndex = -1;
-    grandchild.tabIndex = -1;
-    parent.classList.add('parent');
-    child.classList.add('child');
-    grandchild.classList.add('grandchild');
-    child.appendChild(grandchild);
-    parent.appendChild(child);
+    parent = document.createElement("div")
+    child = document.createElement("div")
+    grandchild = document.createElement("div")
+    parent.tabIndex = -1
+    child.tabIndex = -1
+    grandchild.tabIndex = -1
+    parent.classList.add("parent")
+    child.classList.add("child")
+    grandchild.classList.add("grandchild")
+    child.appendChild(grandchild)
+    parent.appendChild(child)
 
-    document.body.appendChild(parent);
-  });
+    document.body.appendChild(parent)
+  })
 
-  afterEach(function() {
-    document.body.blur();
-    document.body.removeChild(parent);
-  });
+  afterEach(function () {
+    document.body.blur()
+    document.body.removeChild(parent)
+  })
 
-  describe('::add(itemsBySelector)', function() {
-    it('can add top-level menu items that can be removed with the returned disposable', function() {
+  describe("::add(itemsBySelector)", function () {
+    it("can add top-level menu items that can be removed with the returned disposable", function () {
       const disposable = contextMenu.add({
-        '.parent': [{ label: 'A', command: 'a' }],
-        '.child': [{ label: 'B', command: 'b' }],
-        '.grandchild': [{ label: 'C', command: 'c' }]
-      });
+        ".parent": [{label: "A", command: "a"}],
+        ".child": [{label: "B", command: "b"}],
+        ".grandchild": [{label: "C", command: "c"}],
+      })
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'C', id: 'C', command: 'c' },
-        { label: 'B', id: 'B', command: 'b' },
-        { label: 'A', id: 'A', command: 'a' }
-      ]);
+        {label: "C", id: "C", command: "c"},
+        {label: "B", id: "B", command: "b"},
+        {label: "A", id: "A", command: "a"},
+      ])
 
-      disposable.dispose();
-      expect(contextMenu.templateForElement(grandchild)).toEqual([]);
-    });
+      disposable.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual([])
+    })
 
-    it('can add submenu items to existing menus that can be removed with the returned disposable', function() {
+    it("can add submenu items to existing menus that can be removed with the returned disposable", function () {
       const disposable1 = contextMenu.add({
-        '.grandchild': [{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]
-      });
+        ".grandchild": [{label: "A", submenu: [{label: "B", command: "b"}]}],
+      })
       const disposable2 = contextMenu.add({
-        '.grandchild': [{ label: 'A', submenu: [{ label: 'C', command: 'c' }] }]
-      });
+        ".grandchild": [{label: "A", submenu: [{label: "C", command: "c"}]}],
+      })
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
         {
-          label: 'A',
-          id: 'A',
-          submenu: [{ label: 'B', id: 'B', command: 'b' }, { label: 'C', id: 'C', command: 'c' }]
-        }
-      ]);
+          label: "A",
+          id: "A",
+          submenu: [
+            {label: "B", id: "B", command: "b"},
+            {label: "C", id: "C", command: "c"},
+          ],
+        },
+      ])
 
-      disposable2.dispose();
+      disposable2.dispose()
       expect(contextMenu.templateForElement(grandchild)).toEqual([
         {
-          label: 'A',
-          id: 'A',
-          submenu: [{ label: 'B', id: 'B', command: 'b' }]
-        }
-      ]);
+          label: "A",
+          id: "A",
+          submenu: [{label: "B", id: "B", command: "b"}],
+        },
+      ])
 
-      disposable1.dispose();
-      expect(contextMenu.templateForElement(grandchild)).toEqual([]);
-    });
+      disposable1.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual([])
+    })
 
-    it('favors the most specific / recently added item in the case of a duplicate label', function() {
-      grandchild.classList.add('foo');
+    it("favors the most specific / recently added item in the case of a duplicate label", function () {
+      grandchild.classList.add("foo")
 
       const disposable1 = contextMenu.add({
-        '.grandchild': [{ label: 'A', command: 'a' }]
-      });
+        ".grandchild": [{label: "A", command: "a"}],
+      })
       const disposable2 = contextMenu.add({
-        '.grandchild.foo': [{ label: 'A', command: 'b' }]
-      });
+        ".grandchild.foo": [{label: "A", command: "b"}],
+      })
       const disposable3 = contextMenu.add({
-        '.grandchild': [{ label: 'A', command: 'c' }]
-      });
+        ".grandchild": [{label: "A", command: "c"}],
+      })
 
       contextMenu.add({
-        '.child': [{ label: 'A', command: 'd' }]
-      });
+        ".child": [{label: "A", command: "d"}],
+      })
 
-      expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', id: 'A', command: 'b' }
-      ]);
+      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "b"}])
 
-      disposable2.dispose();
-      expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', id: 'A', command: 'c' }
-      ]);
+      disposable2.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "c"}])
 
-      disposable3.dispose();
-      expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', id: 'A', command: 'a' }
-      ]);
+      disposable3.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "a"}])
 
-      disposable1.dispose();
-      expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', id: 'A', command: 'd' }
-      ]);
-    });
+      disposable1.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "d"}])
+    })
 
-    it('allows multiple separators, but not adjacent to each other', function() {
+    it("allows multiple separators, but not adjacent to each other", function () {
       contextMenu.add({
-        '.grandchild': [
-          { label: 'A', command: 'a' },
-          { type: 'separator' },
-          { type: 'separator' },
-          { label: 'B', command: 'b' },
-          { type: 'separator' },
-          { type: 'separator' },
-          { label: 'C', command: 'c' }
-        ]
-      });
+        ".grandchild": [
+          {label: "A", command: "a"},
+          {type: "separator"},
+          {type: "separator"},
+          {label: "B", command: "b"},
+          {type: "separator"},
+          {type: "separator"},
+          {label: "C", command: "c"},
+        ],
+      })
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', id: 'A', command: 'a' },
-        { type: 'separator' },
-        { label: 'B', id: 'B', command: 'b' },
-        { type: 'separator' },
-        { label: 'C', id: 'C', command: 'c' }
-      ]);
-    });
+        {label: "A", id: "A", command: "a"},
+        {type: "separator"},
+        {label: "B", id: "B", command: "b"},
+        {type: "separator"},
+        {label: "C", id: "C", command: "c"},
+      ])
+    })
 
-    it('excludes items marked for display in devMode unless in dev mode', function() {
+    it("excludes items marked for display in devMode unless in dev mode", function () {
       contextMenu.add({
-        '.grandchild': [
-          { label: 'A', command: 'a', devMode: true },
-          { label: 'B', command: 'b', devMode: false }
-        ]
-      });
+        ".grandchild": [
+          {label: "A", command: "a", devMode: true},
+          {label: "B", command: "b", devMode: false},
+        ],
+      })
 
+      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "B", id: "B", command: "b"}])
+
+      contextMenu.devMode = true
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'B', id: 'B', command: 'b' }
-      ]);
+        {label: "A", id: "A", command: "a"},
+        {label: "B", id: "B", command: "b"},
+      ])
+    })
 
-      contextMenu.devMode = true;
-      expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', id: 'A', command: 'a' },
-        { label: 'B', id: 'B', command: 'b' }
-      ]);
-    });
-
-    it('allows items to be associated with `created` hooks which are invoked on template construction with the item and event', function() {
-      let createdEvent = null;
+    it("allows items to be associated with `created` hooks which are invoked on template construction with the item and event", function () {
+      let createdEvent = null
 
       const item = {
-        label: 'A',
-        command: 'a',
+        label: "A",
+        command: "a",
         created(event) {
-          this.command = 'b';
-          createdEvent = event;
-        }
-      };
-
-      contextMenu.add({ '.grandchild': [item] });
-
-      const dispatchedEvent = { target: grandchild };
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        { label: 'A', id: 'A', command: 'b' }
-      ]);
-      expect(item.command).toBe('a'); // doesn't modify original item template
-      expect(createdEvent).toBe(dispatchedEvent);
-    });
-
-    it('allows items to be associated with `shouldDisplay` hooks which are invoked on construction to determine whether the item should be included', function() {
-      let shouldDisplayEvent = null;
-      let shouldDisplay = true;
-
-      const item = {
-        label: 'A',
-        command: 'a',
-        shouldDisplay(event) {
-          this.foo = 'bar';
-          shouldDisplayEvent = event;
-          return shouldDisplay;
-        }
-      };
-      contextMenu.add({ '.grandchild': [item] });
-
-      const dispatchedEvent = { target: grandchild };
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        { label: 'A', id: 'A', command: 'a' }
-      ]);
-      expect(item.foo).toBeUndefined(); // doesn't modify original item template
-      expect(shouldDisplayEvent).toBe(dispatchedEvent);
-
-      shouldDisplay = false;
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([]);
-    });
-
-    it('prunes a trailing separator', function() {
-      contextMenu.add({
-        '.grandchild': [
-          { label: 'A', command: 'a' },
-          { type: 'separator' },
-          { label: 'B', command: 'b' },
-          { type: 'separator' }
-        ]
-      });
-
-      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
-        3
-      );
-    });
-
-    it('prunes a leading separator', function() {
-      contextMenu.add({
-        '.grandchild': [
-          { type: 'separator' },
-          { label: 'A', command: 'a' },
-          { type: 'separator' },
-          { label: 'B', command: 'b' }
-        ]
-      });
-
-      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
-        3
-      );
-    });
-
-    it('prunes duplicate separators', function() {
-      contextMenu.add({
-        '.grandchild': [
-          { label: 'A', command: 'a' },
-          { type: 'separator' },
-          { type: 'separator' },
-          { label: 'B', command: 'b' }
-        ]
-      });
-
-      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
-        3
-      );
-    });
-
-    it('prunes all redundant separators', function() {
-      contextMenu.add({
-        '.grandchild': [
-          { type: 'separator' },
-          { type: 'separator' },
-          { label: 'A', command: 'a' },
-          { type: 'separator' },
-          { type: 'separator' },
-          { label: 'B', command: 'b' },
-          { label: 'C', command: 'c' },
-          { type: 'separator' },
-          { type: 'separator' }
-        ]
-      });
-
-      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
-        4
-      );
-    });
-
-    it('throws an error when the selector is invalid', function() {
-      let addError = null;
-      try {
-        contextMenu.add({ '<>': [{ label: 'A', command: 'a' }] });
-      } catch (error) {
-        addError = error;
+          this.command = "b"
+          createdEvent = event
+        },
       }
-      expect(addError.message).toContain('<>');
-    });
 
-    it('calls `created` hooks for submenu items', function() {
+      contextMenu.add({".grandchild": [item]})
+
+      const dispatchedEvent = {target: grandchild}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([{label: "A", id: "A", command: "b"}])
+      expect(item.command).toBe("a") // doesn't modify original item template
+      expect(createdEvent).toBe(dispatchedEvent)
+    })
+
+    it("allows items to be associated with `shouldDisplay` hooks which are invoked on construction to determine whether the item should be included", function () {
+      let shouldDisplayEvent = null
+      let shouldDisplay = true
+
       const item = {
-        label: 'A',
-        command: 'B',
-        submenu: [
-          {
-            label: 'C',
-            created(event) {
-              this.label = 'D';
-            }
-          }
-        ]
-      };
-      contextMenu.add({ '.grandchild': [item] });
+        label: "A",
+        command: "a",
+        shouldDisplay(event) {
+          this.foo = "bar"
+          shouldDisplayEvent = event
+          return shouldDisplay
+        },
+      }
+      contextMenu.add({".grandchild": [item]})
 
-      const dispatchedEvent = { target: grandchild };
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        {
-          label: 'A',
-          id: 'A',
-          command: 'B',
-          submenu: [
-            {
-              label: 'D',
-              id: 'D'
-            }
-          ]
-        }
-      ]);
-    });
-  });
+      const dispatchedEvent = {target: grandchild}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([{label: "A", id: "A", command: "a"}])
+      expect(item.foo).toBeUndefined() // doesn't modify original item template
+      expect(shouldDisplayEvent).toBe(dispatchedEvent)
 
-  describe('::templateForEvent(target)', function() {
-    let [keymaps, item] = [];
+      shouldDisplay = false
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([])
+    })
 
-    beforeEach(function() {
-      keymaps = atom.keymaps.add('source', {
-        '.child': {
-          'ctrl-a': 'test:my-command',
-          'shift-b': 'test:my-other-command'
-        }
-      });
-      item = {
-        label: 'My Command',
-        command: 'test:my-command',
-        submenu: [
-          {
-            label: 'My Other Command',
-            command: 'test:my-other-command'
-          }
-        ]
-      };
-      contextMenu.add({ '.parent': [item] });
-    });
-
-    afterEach(() => keymaps.dispose());
-
-    it('adds Electron-style accelerators to items that have keybindings', function() {
-      child.focus();
-      const dispatchedEvent = { target: child };
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        {
-          label: 'My Command',
-          id: 'My Command',
-          command: 'test:my-command',
-          accelerator: 'Ctrl+A',
-          submenu: [
-            {
-              label: 'My Other Command',
-              id: 'My Other Command',
-              command: 'test:my-other-command',
-              accelerator: 'Shift+B'
-            }
-          ]
-        }
-      ]);
-    });
-
-    it('adds accelerators when a parent node has key bindings for a given command', function() {
-      grandchild.focus();
-      const dispatchedEvent = { target: grandchild };
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        {
-          label: 'My Command',
-          id: 'My Command',
-          command: 'test:my-command',
-          accelerator: 'Ctrl+A',
-          submenu: [
-            {
-              label: 'My Other Command',
-              id: 'My Other Command',
-              command: 'test:my-other-command',
-              accelerator: 'Shift+B'
-            }
-          ]
-        }
-      ]);
-    });
-
-    it('does not add accelerators when a child node has key bindings for a given command', function() {
-      parent.focus();
-      const dispatchedEvent = { target: parent };
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        {
-          label: 'My Command',
-          id: 'My Command',
-          command: 'test:my-command',
-          submenu: [
-            {
-              label: 'My Other Command',
-              id: 'My Other Command',
-              command: 'test:my-other-command'
-            }
-          ]
-        }
-      ]);
-    });
-
-    it('adds accelerators based on focus, not context menu target', function() {
-      grandchild.focus();
-      const dispatchedEvent = { target: parent };
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        {
-          label: 'My Command',
-          id: 'My Command',
-          command: 'test:my-command',
-          accelerator: 'Ctrl+A',
-          submenu: [
-            {
-              label: 'My Other Command',
-              id: 'My Other Command',
-              command: 'test:my-other-command',
-              accelerator: 'Shift+B'
-            }
-          ]
-        }
-      ]);
-    });
-
-    it('does not add accelerators for multi-keystroke key bindings', function() {
-      atom.keymaps.add('source', {
-        '.child': {
-          'ctrl-a ctrl-b': 'test:multi-keystroke-command'
-        }
-      });
-      contextMenu.clear();
+    it("prunes a trailing separator", function () {
       contextMenu.add({
-        '.parent': [
+        ".grandchild": [
+          {label: "A", command: "a"},
+          {type: "separator"},
+          {label: "B", command: "b"},
+          {type: "separator"},
+        ],
+      })
+
+      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(3)
+    })
+
+    it("prunes a leading separator", function () {
+      contextMenu.add({
+        ".grandchild": [
+          {type: "separator"},
+          {label: "A", command: "a"},
+          {type: "separator"},
+          {label: "B", command: "b"},
+        ],
+      })
+
+      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(3)
+    })
+
+    it("prunes duplicate separators", function () {
+      contextMenu.add({
+        ".grandchild": [
+          {label: "A", command: "a"},
+          {type: "separator"},
+          {type: "separator"},
+          {label: "B", command: "b"},
+        ],
+      })
+
+      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(3)
+    })
+
+    it("prunes all redundant separators", function () {
+      contextMenu.add({
+        ".grandchild": [
+          {type: "separator"},
+          {type: "separator"},
+          {label: "A", command: "a"},
+          {type: "separator"},
+          {type: "separator"},
+          {label: "B", command: "b"},
+          {label: "C", command: "c"},
+          {type: "separator"},
+          {type: "separator"},
+        ],
+      })
+
+      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(4)
+    })
+
+    it("throws an error when the selector is invalid", function () {
+      let addError = null
+      try {
+        contextMenu.add({"<>": [{label: "A", command: "a"}]})
+      } catch (error) {
+        addError = error
+      }
+      expect(addError.message).toContain("<>")
+    })
+
+    it("calls `created` hooks for submenu items", function () {
+      const item = {
+        label: "A",
+        command: "B",
+        submenu: [
           {
-            label: 'Multi-keystroke command',
-            command: 'test:multi-keystroke-command'
-          }
-        ]
-      });
+            label: "C",
+            created(event) {
+              this.label = "D"
+            },
+          },
+        ],
+      }
+      contextMenu.add({".grandchild": [item]})
 
-      child.focus();
+      const dispatchedEvent = {target: grandchild}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
+        {
+          label: "A",
+          id: "A",
+          command: "B",
+          submenu: [
+            {
+              label: "D",
+              id: "D",
+            },
+          ],
+        },
+      ])
+    })
+  })
 
-      const label = process.platform === 'darwin' ? '⌃A ⌃B' : 'Ctrl+A Ctrl+B';
-      expect(contextMenu.templateForEvent({ target: child })).toEqual([
+  describe("::templateForEvent(target)", function () {
+    let [keymaps, item] = []
+
+    beforeEach(function () {
+      keymaps = atom.keymaps.add("source", {
+        ".child": {
+          "ctrl-a": "test:my-command",
+          "shift-b": "test:my-other-command",
+        },
+      })
+      item = {
+        label: "My Command",
+        command: "test:my-command",
+        submenu: [
+          {
+            label: "My Other Command",
+            command: "test:my-other-command",
+          },
+        ],
+      }
+      contextMenu.add({".parent": [item]})
+    })
+
+    afterEach(() => keymaps.dispose())
+
+    it("adds Electron-style accelerators to items that have keybindings", function () {
+      child.focus()
+      const dispatchedEvent = {target: child}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
+        {
+          label: "My Command",
+          id: "My Command",
+          command: "test:my-command",
+          accelerator: "Ctrl+A",
+          submenu: [
+            {
+              label: "My Other Command",
+              id: "My Other Command",
+              command: "test:my-other-command",
+              accelerator: "Shift+B",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("adds accelerators when a parent node has key bindings for a given command", function () {
+      grandchild.focus()
+      const dispatchedEvent = {target: grandchild}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
+        {
+          label: "My Command",
+          id: "My Command",
+          command: "test:my-command",
+          accelerator: "Ctrl+A",
+          submenu: [
+            {
+              label: "My Other Command",
+              id: "My Other Command",
+              command: "test:my-other-command",
+              accelerator: "Shift+B",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("does not add accelerators when a child node has key bindings for a given command", function () {
+      parent.focus()
+      const dispatchedEvent = {target: parent}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
+        {
+          label: "My Command",
+          id: "My Command",
+          command: "test:my-command",
+          submenu: [
+            {
+              label: "My Other Command",
+              id: "My Other Command",
+              command: "test:my-other-command",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("adds accelerators based on focus, not context menu target", function () {
+      grandchild.focus()
+      const dispatchedEvent = {target: parent}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
+        {
+          label: "My Command",
+          id: "My Command",
+          command: "test:my-command",
+          accelerator: "Ctrl+A",
+          submenu: [
+            {
+              label: "My Other Command",
+              id: "My Other Command",
+              command: "test:my-other-command",
+              accelerator: "Shift+B",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("does not add accelerators for multi-keystroke key bindings", function () {
+      atom.keymaps.add("source", {
+        ".child": {
+          "ctrl-a ctrl-b": "test:multi-keystroke-command",
+        },
+      })
+      contextMenu.clear()
+      contextMenu.add({
+        ".parent": [
+          {
+            label: "Multi-keystroke command",
+            command: "test:multi-keystroke-command",
+          },
+        ],
+      })
+
+      child.focus()
+
+      const label = process.platform === "darwin" ? "⌃A ⌃B" : "Ctrl+A Ctrl+B"
+      expect(contextMenu.templateForEvent({target: child})).toEqual([
         {
           label: `Multi-keystroke command [${label}]`,
           id: `Multi-keystroke command`,
-          command: 'test:multi-keystroke-command'
-        }
-      ]);
-    });
-  });
+          command: "test:multi-keystroke-command",
+        },
+      ])
+    })
+  })
 
-  describe('::templateForEvent(target) (sorting)', function() {
-    it('applies simple sorting rules', function() {
+  describe("::templateForEvent(target) (sorting)", function () {
+    it("applies simple sorting rules", function () {
       contextMenu.add({
-        '.parent': [
+        ".parent": [
           {
-            label: 'My Command',
-            command: 'test:my-command',
-            after: ['test:my-other-command']
+            label: "My Command",
+            command: "test:my-command",
+            after: ["test:my-other-command"],
           },
           {
-            label: 'My Other Command',
-            command: 'test:my-other-command'
-          }
-        ]
-      });
-      const dispatchedEvent = { target: parent };
+            label: "My Other Command",
+            command: "test:my-other-command",
+          },
+        ],
+      })
+      const dispatchedEvent = {target: parent}
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: 'My Other Command',
-          id: 'My Other Command',
-          command: 'test:my-other-command'
+          label: "My Other Command",
+          id: "My Other Command",
+          command: "test:my-other-command",
         },
         {
-          label: 'My Command',
-          id: 'My Command',
-          command: 'test:my-command',
-          after: ['test:my-other-command']
-        }
-      ]);
-    });
+          label: "My Command",
+          id: "My Command",
+          command: "test:my-command",
+          after: ["test:my-other-command"],
+        },
+      ])
+    })
 
-    it('applies sorting rules recursively to submenus', function() {
+    it("applies sorting rules recursively to submenus", function () {
       contextMenu.add({
-        '.parent': [
+        ".parent": [
           {
-            label: 'Parent',
+            label: "Parent",
             submenu: [
               {
-                label: 'My Command',
-                command: 'test:my-command',
-                after: ['test:my-other-command']
+                label: "My Command",
+                command: "test:my-command",
+                after: ["test:my-other-command"],
               },
               {
-                label: 'My Other Command',
-                command: 'test:my-other-command'
-              }
-            ]
-          }
-        ]
-      });
-      const dispatchedEvent = { target: parent };
+                label: "My Other Command",
+                command: "test:my-other-command",
+              },
+            ],
+          },
+        ],
+      })
+      const dispatchedEvent = {target: parent}
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: 'Parent',
+          label: "Parent",
           id: `Parent`,
           submenu: [
             {
-              label: 'My Other Command',
-              id: 'My Other Command',
-              command: 'test:my-other-command'
+              label: "My Other Command",
+              id: "My Other Command",
+              command: "test:my-other-command",
             },
             {
-              label: 'My Command',
-              id: 'My Command',
-              command: 'test:my-command',
-              after: ['test:my-other-command']
-            }
-          ]
-        }
-      ]);
-    });
-  });
-});
+              label: "My Command",
+              id: "My Command",
+              command: "test:my-command",
+              after: ["test:my-other-command"],
+            },
+          ],
+        },
+      ])
+    })
+  })
+})

--- a/spec/context-menu-manager-spec.js
+++ b/spec/context-menu-manager-spec.js
@@ -37,9 +37,9 @@ describe('ContextMenuManager', function() {
       });
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'C', command: 'c' },
-        { label: 'B', command: 'b' },
-        { label: 'A', command: 'a' }
+        { label: 'C', id: 'C', command: 'c' },
+        { label: 'B', id: 'B', command: 'b' },
+        { label: 'A', id: 'A', command: 'a' }
       ]);
 
       disposable.dispose();
@@ -57,7 +57,8 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForElement(grandchild)).toEqual([
         {
           label: 'A',
-          submenu: [{ label: 'B', command: 'b' }, { label: 'C', command: 'c' }]
+          id: 'A',
+          submenu: [{ label: 'B', id: 'B', command: 'b' }, { label: 'C', id: 'C', command: 'c' }]
         }
       ]);
 
@@ -65,7 +66,8 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForElement(grandchild)).toEqual([
         {
           label: 'A',
-          submenu: [{ label: 'B', command: 'b' }]
+          id: 'A',
+          submenu: [{ label: 'B', id: 'B', command: 'b' }]
         }
       ]);
 
@@ -91,22 +93,22 @@ describe('ContextMenuManager', function() {
       });
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', command: 'b' }
+        { label: 'A', id: 'A', command: 'b' }
       ]);
 
       disposable2.dispose();
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', command: 'c' }
+        { label: 'A', id: 'A', command: 'c' }
       ]);
 
       disposable3.dispose();
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', command: 'a' }
+        { label: 'A', id: 'A', command: 'a' }
       ]);
 
       disposable1.dispose();
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', command: 'd' }
+        { label: 'A', id: 'A', command: 'd' }
       ]);
     });
 
@@ -124,11 +126,11 @@ describe('ContextMenuManager', function() {
       });
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', command: 'a' },
+        { label: 'A', id: 'A', command: 'a' },
         { type: 'separator' },
-        { label: 'B', command: 'b' },
+        { label: 'B', id: 'B', command: 'b' },
         { type: 'separator' },
-        { label: 'C', command: 'c' }
+        { label: 'C', id: 'C', command: 'c' }
       ]);
     });
 
@@ -141,13 +143,13 @@ describe('ContextMenuManager', function() {
       });
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'B', command: 'b' }
+        { label: 'B', id: 'B', command: 'b' }
       ]);
 
       contextMenu.devMode = true;
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        { label: 'A', command: 'a' },
-        { label: 'B', command: 'b' }
+        { label: 'A', id: 'A', command: 'a' },
+        { label: 'B', id: 'B', command: 'b' }
       ]);
     });
 
@@ -167,7 +169,7 @@ describe('ContextMenuManager', function() {
 
       const dispatchedEvent = { target: grandchild };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        { label: 'A', command: 'b' }
+        { label: 'A', id: 'A', command: 'b' }
       ]);
       expect(item.command).toBe('a'); // doesn't modify original item template
       expect(createdEvent).toBe(dispatchedEvent);
@@ -190,7 +192,7 @@ describe('ContextMenuManager', function() {
 
       const dispatchedEvent = { target: grandchild };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
-        { label: 'A', command: 'a' }
+        { label: 'A', id: 'A', command: 'a' }
       ]);
       expect(item.foo).toBeUndefined(); // doesn't modify original item template
       expect(shouldDisplayEvent).toBe(dispatchedEvent);
@@ -293,10 +295,12 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
           label: 'A',
+          id: 'A',
           command: 'B',
           submenu: [
             {
-              label: 'D'
+              label: 'D',
+              id: 'D'
             }
           ]
         }
@@ -335,11 +339,13 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
           label: 'My Command',
+          id: 'My Command',
           command: 'test:my-command',
           accelerator: 'Ctrl+A',
           submenu: [
             {
               label: 'My Other Command',
+              id: 'My Other Command',
               command: 'test:my-other-command',
               accelerator: 'Shift+B'
             }
@@ -354,11 +360,13 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
           label: 'My Command',
+          id: 'My Command',
           command: 'test:my-command',
           accelerator: 'Ctrl+A',
           submenu: [
             {
               label: 'My Other Command',
+              id: 'My Other Command',
               command: 'test:my-other-command',
               accelerator: 'Shift+B'
             }
@@ -373,10 +381,12 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
           label: 'My Command',
+          id: 'My Command',
           command: 'test:my-command',
           submenu: [
             {
               label: 'My Other Command',
+              id: 'My Other Command',
               command: 'test:my-other-command'
             }
           ]
@@ -390,11 +400,13 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
           label: 'My Command',
+          id: 'My Command',
           command: 'test:my-command',
           accelerator: 'Ctrl+A',
           submenu: [
             {
               label: 'My Other Command',
+              id: 'My Other Command',
               command: 'test:my-other-command',
               accelerator: 'Shift+B'
             }
@@ -425,6 +437,7 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForEvent({ target: child })).toEqual([
         {
           label: `Multi-keystroke command [${label}]`,
+          id: `Multi-keystroke command`,
           command: 'test:multi-keystroke-command'
         }
       ]);
@@ -450,10 +463,12 @@ describe('ContextMenuManager', function() {
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
           label: 'My Other Command',
+          id: 'My Other Command',
           command: 'test:my-other-command'
         },
         {
           label: 'My Command',
+          id: 'My Command',
           command: 'test:my-command',
           after: ['test:my-other-command']
         }
@@ -464,6 +479,7 @@ describe('ContextMenuManager', function() {
       contextMenu.add({
         '.parent': [
           {
+            label: 'Parent',
             submenu: [
               {
                 label: 'My Command',
@@ -481,13 +497,17 @@ describe('ContextMenuManager', function() {
       const dispatchedEvent = { target: parent };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
+          label: 'Parent',
+          id: `Parent`,
           submenu: [
             {
               label: 'My Other Command',
+              id: 'My Other Command',
               command: 'test:my-other-command'
             },
             {
               label: 'My Command',
+              id: 'My Command',
               command: 'test:my-command',
               after: ['test:my-other-command']
             }

--- a/spec/context-menu-manager-spec.js
+++ b/spec/context-menu-manager-spec.js
@@ -1,500 +1,522 @@
-const ContextMenuManager = require("../src/context-menu-manager")
+const ContextMenuManager = require('../src/context-menu-manager');
 
-describe("ContextMenuManager", function () {
-  let [contextMenu, parent, child, grandchild] = []
+describe('ContextMenuManager', function() {
+  let [contextMenu, parent, child, grandchild] = [];
 
-  beforeEach(function () {
-    const {resourcePath} = atom.getLoadSettings()
-    contextMenu = new ContextMenuManager({keymapManager: atom.keymaps})
-    contextMenu.initialize({resourcePath})
+  beforeEach(function() {
+    const { resourcePath } = atom.getLoadSettings();
+    contextMenu = new ContextMenuManager({ keymapManager: atom.keymaps });
+    contextMenu.initialize({ resourcePath });
 
-    parent = document.createElement("div")
-    child = document.createElement("div")
-    grandchild = document.createElement("div")
-    parent.tabIndex = -1
-    child.tabIndex = -1
-    grandchild.tabIndex = -1
-    parent.classList.add("parent")
-    child.classList.add("child")
-    grandchild.classList.add("grandchild")
-    child.appendChild(grandchild)
-    parent.appendChild(child)
+    parent = document.createElement('div');
+    child = document.createElement('div');
+    grandchild = document.createElement('div');
+    parent.tabIndex = -1;
+    child.tabIndex = -1;
+    grandchild.tabIndex = -1;
+    parent.classList.add('parent');
+    child.classList.add('child');
+    grandchild.classList.add('grandchild');
+    child.appendChild(grandchild);
+    parent.appendChild(child);
 
-    document.body.appendChild(parent)
-  })
+    document.body.appendChild(parent);
+  });
 
-  afterEach(function () {
-    document.body.blur()
-    document.body.removeChild(parent)
-  })
+  afterEach(function() {
+    document.body.blur();
+    document.body.removeChild(parent);
+  });
 
-  describe("::add(itemsBySelector)", function () {
-    it("can add top-level menu items that can be removed with the returned disposable", function () {
+  describe('::add(itemsBySelector)', function() {
+    it('can add top-level menu items that can be removed with the returned disposable', function() {
       const disposable = contextMenu.add({
-        ".parent": [{label: "A", command: "a"}],
-        ".child": [{label: "B", command: "b"}],
-        ".grandchild": [{label: "C", command: "c"}],
-      })
+        '.parent': [{ label: 'A', command: 'a' }],
+        '.child': [{ label: 'B', command: 'b' }],
+        '.grandchild': [{ label: 'C', command: 'c' }]
+      });
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        {label: "C", id: "C", command: "c"},
-        {label: "B", id: "B", command: "b"},
-        {label: "A", id: "A", command: "a"},
-      ])
+        { label: 'C', id: 'C', command: 'c' },
+        { label: 'B', id: 'B', command: 'b' },
+        { label: 'A', id: 'A', command: 'a' }
+      ]);
 
-      disposable.dispose()
-      expect(contextMenu.templateForElement(grandchild)).toEqual([])
-    })
+      disposable.dispose();
+      expect(contextMenu.templateForElement(grandchild)).toEqual([]);
+    });
 
-    it("can add submenu items to existing menus that can be removed with the returned disposable", function () {
+    it('can add submenu items to existing menus that can be removed with the returned disposable', function() {
       const disposable1 = contextMenu.add({
-        ".grandchild": [{label: "A", submenu: [{label: "B", command: "b"}]}],
-      })
+        '.grandchild': [{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]
+      });
       const disposable2 = contextMenu.add({
-        ".grandchild": [{label: "A", submenu: [{label: "C", command: "c"}]}],
-      })
+        '.grandchild': [{ label: 'A', submenu: [{ label: 'C', command: 'c' }] }]
+      });
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
         {
-          label: "A",
-          id: "A",
+          label: 'A',
+          id: 'A',
           submenu: [
-            {label: "B", id: "B", command: "b"},
-            {label: "C", id: "C", command: "c"},
-          ],
-        },
-      ])
+            { label: 'B', id: 'B', command: 'b' },
+            { label: 'C', id: 'C', command: 'c' }
+          ]
+        }
+      ]);
 
-      disposable2.dispose()
+      disposable2.dispose();
       expect(contextMenu.templateForElement(grandchild)).toEqual([
         {
-          label: "A",
-          id: "A",
-          submenu: [{label: "B", id: "B", command: "b"}],
-        },
-      ])
+          label: 'A',
+          id: 'A',
+          submenu: [{ label: 'B', id: 'B', command: 'b' }]
+        }
+      ]);
 
-      disposable1.dispose()
-      expect(contextMenu.templateForElement(grandchild)).toEqual([])
-    })
+      disposable1.dispose();
+      expect(contextMenu.templateForElement(grandchild)).toEqual([]);
+    });
 
-    it("favors the most specific / recently added item in the case of a duplicate label", function () {
-      grandchild.classList.add("foo")
+    it('favors the most specific / recently added item in the case of a duplicate label', function() {
+      grandchild.classList.add('foo');
 
       const disposable1 = contextMenu.add({
-        ".grandchild": [{label: "A", command: "a"}],
-      })
+        '.grandchild': [{ label: 'A', command: 'a' }]
+      });
       const disposable2 = contextMenu.add({
-        ".grandchild.foo": [{label: "A", command: "b"}],
-      })
+        '.grandchild.foo': [{ label: 'A', command: 'b' }]
+      });
       const disposable3 = contextMenu.add({
-        ".grandchild": [{label: "A", command: "c"}],
-      })
+        '.grandchild': [{ label: 'A', command: 'c' }]
+      });
 
       contextMenu.add({
-        ".child": [{label: "A", command: "d"}],
-      })
-
-      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "b"}])
-
-      disposable2.dispose()
-      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "c"}])
-
-      disposable3.dispose()
-      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "a"}])
-
-      disposable1.dispose()
-      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "A", id: "A", command: "d"}])
-    })
-
-    it("allows multiple separators, but not adjacent to each other", function () {
-      contextMenu.add({
-        ".grandchild": [
-          {label: "A", command: "a"},
-          {type: "separator"},
-          {type: "separator"},
-          {label: "B", command: "b"},
-          {type: "separator"},
-          {type: "separator"},
-          {label: "C", command: "c"},
-        ],
-      })
+        '.child': [{ label: 'A', command: 'd' }]
+      });
 
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        {label: "A", id: "A", command: "a"},
-        {type: "separator"},
-        {label: "B", id: "B", command: "b"},
-        {type: "separator"},
-        {label: "C", id: "C", command: "c"},
-      ])
-    })
+        { label: 'A', id: 'A', command: 'b' }
+      ]);
 
-    it("excludes items marked for display in devMode unless in dev mode", function () {
-      contextMenu.add({
-        ".grandchild": [
-          {label: "A", command: "a", devMode: true},
-          {label: "B", command: "b", devMode: false},
-        ],
-      })
-
-      expect(contextMenu.templateForElement(grandchild)).toEqual([{label: "B", id: "B", command: "b"}])
-
-      contextMenu.devMode = true
+      disposable2.dispose();
       expect(contextMenu.templateForElement(grandchild)).toEqual([
-        {label: "A", id: "A", command: "a"},
-        {label: "B", id: "B", command: "b"},
-      ])
-    })
+        { label: 'A', id: 'A', command: 'c' }
+      ]);
 
-    it("allows items to be associated with `created` hooks which are invoked on template construction with the item and event", function () {
-      let createdEvent = null
+      disposable3.dispose();
+      expect(contextMenu.templateForElement(grandchild)).toEqual([
+        { label: 'A', id: 'A', command: 'a' }
+      ]);
+
+      disposable1.dispose();
+      expect(contextMenu.templateForElement(grandchild)).toEqual([
+        { label: 'A', id: 'A', command: 'd' }
+      ]);
+    });
+
+    it('allows multiple separators, but not adjacent to each other', function() {
+      contextMenu.add({
+        '.grandchild': [
+          { label: 'A', command: 'a' },
+          { type: 'separator' },
+          { type: 'separator' },
+          { label: 'B', command: 'b' },
+          { type: 'separator' },
+          { type: 'separator' },
+          { label: 'C', command: 'c' }
+        ]
+      });
+
+      expect(contextMenu.templateForElement(grandchild)).toEqual([
+        { label: 'A', id: 'A', command: 'a' },
+        { type: 'separator' },
+        { label: 'B', id: 'B', command: 'b' },
+        { type: 'separator' },
+        { label: 'C', id: 'C', command: 'c' }
+      ]);
+    });
+
+    it('excludes items marked for display in devMode unless in dev mode', function() {
+      contextMenu.add({
+        '.grandchild': [
+          { label: 'A', command: 'a', devMode: true },
+          { label: 'B', command: 'b', devMode: false }
+        ]
+      });
+
+      expect(contextMenu.templateForElement(grandchild)).toEqual([
+        { label: 'B', id: 'B', command: 'b' }
+      ]);
+
+      contextMenu.devMode = true;
+      expect(contextMenu.templateForElement(grandchild)).toEqual([
+        { label: 'A', id: 'A', command: 'a' },
+        { label: 'B', id: 'B', command: 'b' }
+      ]);
+    });
+
+    it('allows items to be associated with `created` hooks which are invoked on template construction with the item and event', function() {
+      let createdEvent = null;
 
       const item = {
-        label: "A",
-        command: "a",
+        label: 'A',
+        command: 'a',
         created(event) {
-          this.command = "b"
-          createdEvent = event
-        },
-      }
+          this.command = 'b';
+          createdEvent = event;
+        }
+      };
 
-      contextMenu.add({".grandchild": [item]})
+      contextMenu.add({ '.grandchild': [item] });
 
-      const dispatchedEvent = {target: grandchild}
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([{label: "A", id: "A", command: "b"}])
-      expect(item.command).toBe("a") // doesn't modify original item template
-      expect(createdEvent).toBe(dispatchedEvent)
-    })
+      const dispatchedEvent = { target: grandchild };
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
+        { label: 'A', id: 'A', command: 'b' }
+      ]);
+      expect(item.command).toBe('a'); // doesn't modify original item template
+      expect(createdEvent).toBe(dispatchedEvent);
+    });
 
-    it("allows items to be associated with `shouldDisplay` hooks which are invoked on construction to determine whether the item should be included", function () {
-      let shouldDisplayEvent = null
-      let shouldDisplay = true
+    it('allows items to be associated with `shouldDisplay` hooks which are invoked on construction to determine whether the item should be included', function() {
+      let shouldDisplayEvent = null;
+      let shouldDisplay = true;
 
       const item = {
-        label: "A",
-        command: "a",
+        label: 'A',
+        command: 'a',
         shouldDisplay(event) {
-          this.foo = "bar"
-          shouldDisplayEvent = event
-          return shouldDisplay
-        },
-      }
-      contextMenu.add({".grandchild": [item]})
+          this.foo = 'bar';
+          shouldDisplayEvent = event;
+          return shouldDisplay;
+        }
+      };
+      contextMenu.add({ '.grandchild': [item] });
 
-      const dispatchedEvent = {target: grandchild}
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([{label: "A", id: "A", command: "a"}])
-      expect(item.foo).toBeUndefined() // doesn't modify original item template
-      expect(shouldDisplayEvent).toBe(dispatchedEvent)
+      const dispatchedEvent = { target: grandchild };
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
+        { label: 'A', id: 'A', command: 'a' }
+      ]);
+      expect(item.foo).toBeUndefined(); // doesn't modify original item template
+      expect(shouldDisplayEvent).toBe(dispatchedEvent);
 
-      shouldDisplay = false
-      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([])
-    })
+      shouldDisplay = false;
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([]);
+    });
 
-    it("prunes a trailing separator", function () {
+    it('prunes a trailing separator', function() {
       contextMenu.add({
-        ".grandchild": [
-          {label: "A", command: "a"},
-          {type: "separator"},
-          {label: "B", command: "b"},
-          {type: "separator"},
-        ],
-      })
+        '.grandchild': [
+          { label: 'A', command: 'a' },
+          { type: 'separator' },
+          { label: 'B', command: 'b' },
+          { type: 'separator' }
+        ]
+      });
 
-      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(3)
-    })
+      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
+        3
+      );
+    });
 
-    it("prunes a leading separator", function () {
+    it('prunes a leading separator', function() {
       contextMenu.add({
-        ".grandchild": [
-          {type: "separator"},
-          {label: "A", command: "a"},
-          {type: "separator"},
-          {label: "B", command: "b"},
-        ],
-      })
+        '.grandchild': [
+          { type: 'separator' },
+          { label: 'A', command: 'a' },
+          { type: 'separator' },
+          { label: 'B', command: 'b' }
+        ]
+      });
 
-      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(3)
-    })
+      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
+        3
+      );
+    });
 
-    it("prunes duplicate separators", function () {
+    it('prunes duplicate separators', function() {
       contextMenu.add({
-        ".grandchild": [
-          {label: "A", command: "a"},
-          {type: "separator"},
-          {type: "separator"},
-          {label: "B", command: "b"},
-        ],
-      })
+        '.grandchild': [
+          { label: 'A', command: 'a' },
+          { type: 'separator' },
+          { type: 'separator' },
+          { label: 'B', command: 'b' }
+        ]
+      });
 
-      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(3)
-    })
+      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
+        3
+      );
+    });
 
-    it("prunes all redundant separators", function () {
+    it('prunes all redundant separators', function() {
       contextMenu.add({
-        ".grandchild": [
-          {type: "separator"},
-          {type: "separator"},
-          {label: "A", command: "a"},
-          {type: "separator"},
-          {type: "separator"},
-          {label: "B", command: "b"},
-          {label: "C", command: "c"},
-          {type: "separator"},
-          {type: "separator"},
-        ],
-      })
+        '.grandchild': [
+          { type: 'separator' },
+          { type: 'separator' },
+          { label: 'A', command: 'a' },
+          { type: 'separator' },
+          { type: 'separator' },
+          { label: 'B', command: 'b' },
+          { label: 'C', command: 'c' },
+          { type: 'separator' },
+          { type: 'separator' }
+        ]
+      });
 
-      expect(contextMenu.templateForEvent({target: grandchild}).length).toBe(4)
-    })
+      expect(contextMenu.templateForEvent({ target: grandchild }).length).toBe(
+        4
+      );
+    });
 
-    it("throws an error when the selector is invalid", function () {
-      let addError = null
+    it('throws an error when the selector is invalid', function() {
+      let addError = null;
       try {
-        contextMenu.add({"<>": [{label: "A", command: "a"}]})
+        contextMenu.add({ '<>': [{ label: 'A', command: 'a' }] });
       } catch (error) {
-        addError = error
+        addError = error;
       }
-      expect(addError.message).toContain("<>")
-    })
+      expect(addError.message).toContain('<>');
+    });
 
-    it("calls `created` hooks for submenu items", function () {
+    it('calls `created` hooks for submenu items', function() {
       const item = {
-        label: "A",
-        command: "B",
+        label: 'A',
+        command: 'B',
         submenu: [
           {
-            label: "C",
+            label: 'C',
             created(event) {
-              this.label = "D"
-            },
-          },
-        ],
-      }
-      contextMenu.add({".grandchild": [item]})
+              this.label = 'D';
+            }
+          }
+        ]
+      };
+      contextMenu.add({ '.grandchild': [item] });
 
-      const dispatchedEvent = {target: grandchild}
+      const dispatchedEvent = { target: grandchild };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: "A",
-          id: "A",
-          command: "B",
+          label: 'A',
+          id: 'A',
+          command: 'B',
           submenu: [
             {
-              label: "D",
-              id: "D",
-            },
-          ],
-        },
-      ])
-    })
-  })
+              label: 'D',
+              id: 'D'
+            }
+          ]
+        }
+      ]);
+    });
+  });
 
-  describe("::templateForEvent(target)", function () {
-    let [keymaps, item] = []
+  describe('::templateForEvent(target)', function() {
+    let [keymaps, item] = [];
 
-    beforeEach(function () {
-      keymaps = atom.keymaps.add("source", {
-        ".child": {
-          "ctrl-a": "test:my-command",
-          "shift-b": "test:my-other-command",
-        },
-      })
+    beforeEach(function() {
+      keymaps = atom.keymaps.add('source', {
+        '.child': {
+          'ctrl-a': 'test:my-command',
+          'shift-b': 'test:my-other-command'
+        }
+      });
       item = {
-        label: "My Command",
-        command: "test:my-command",
+        label: 'My Command',
+        command: 'test:my-command',
         submenu: [
           {
-            label: "My Other Command",
-            command: "test:my-other-command",
-          },
-        ],
-      }
-      contextMenu.add({".parent": [item]})
-    })
+            label: 'My Other Command',
+            command: 'test:my-other-command'
+          }
+        ]
+      };
+      contextMenu.add({ '.parent': [item] });
+    });
 
-    afterEach(() => keymaps.dispose())
+    afterEach(() => keymaps.dispose());
 
-    it("adds Electron-style accelerators to items that have keybindings", function () {
-      child.focus()
-      const dispatchedEvent = {target: child}
+    it('adds Electron-style accelerators to items that have keybindings', function() {
+      child.focus();
+      const dispatchedEvent = { target: child };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: "My Command",
-          id: "My Command",
-          command: "test:my-command",
-          accelerator: "Ctrl+A",
+          label: 'My Command',
+          id: 'My Command',
+          command: 'test:my-command',
+          accelerator: 'Ctrl+A',
           submenu: [
             {
-              label: "My Other Command",
-              id: "My Other Command",
-              command: "test:my-other-command",
-              accelerator: "Shift+B",
-            },
-          ],
-        },
-      ])
-    })
+              label: 'My Other Command',
+              id: 'My Other Command',
+              command: 'test:my-other-command',
+              accelerator: 'Shift+B'
+            }
+          ]
+        }
+      ]);
+    });
 
-    it("adds accelerators when a parent node has key bindings for a given command", function () {
-      grandchild.focus()
-      const dispatchedEvent = {target: grandchild}
+    it('adds accelerators when a parent node has key bindings for a given command', function() {
+      grandchild.focus();
+      const dispatchedEvent = { target: grandchild };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: "My Command",
-          id: "My Command",
-          command: "test:my-command",
-          accelerator: "Ctrl+A",
+          label: 'My Command',
+          id: 'My Command',
+          command: 'test:my-command',
+          accelerator: 'Ctrl+A',
           submenu: [
             {
-              label: "My Other Command",
-              id: "My Other Command",
-              command: "test:my-other-command",
-              accelerator: "Shift+B",
-            },
-          ],
-        },
-      ])
-    })
+              label: 'My Other Command',
+              id: 'My Other Command',
+              command: 'test:my-other-command',
+              accelerator: 'Shift+B'
+            }
+          ]
+        }
+      ]);
+    });
 
-    it("does not add accelerators when a child node has key bindings for a given command", function () {
-      parent.focus()
-      const dispatchedEvent = {target: parent}
+    it('does not add accelerators when a child node has key bindings for a given command', function() {
+      parent.focus();
+      const dispatchedEvent = { target: parent };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: "My Command",
-          id: "My Command",
-          command: "test:my-command",
+          label: 'My Command',
+          id: 'My Command',
+          command: 'test:my-command',
           submenu: [
             {
-              label: "My Other Command",
-              id: "My Other Command",
-              command: "test:my-other-command",
-            },
-          ],
-        },
-      ])
-    })
+              label: 'My Other Command',
+              id: 'My Other Command',
+              command: 'test:my-other-command'
+            }
+          ]
+        }
+      ]);
+    });
 
-    it("adds accelerators based on focus, not context menu target", function () {
-      grandchild.focus()
-      const dispatchedEvent = {target: parent}
+    it('adds accelerators based on focus, not context menu target', function() {
+      grandchild.focus();
+      const dispatchedEvent = { target: parent };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: "My Command",
-          id: "My Command",
-          command: "test:my-command",
-          accelerator: "Ctrl+A",
+          label: 'My Command',
+          id: 'My Command',
+          command: 'test:my-command',
+          accelerator: 'Ctrl+A',
           submenu: [
             {
-              label: "My Other Command",
-              id: "My Other Command",
-              command: "test:my-other-command",
-              accelerator: "Shift+B",
-            },
-          ],
-        },
-      ])
-    })
+              label: 'My Other Command',
+              id: 'My Other Command',
+              command: 'test:my-other-command',
+              accelerator: 'Shift+B'
+            }
+          ]
+        }
+      ]);
+    });
 
-    it("does not add accelerators for multi-keystroke key bindings", function () {
-      atom.keymaps.add("source", {
-        ".child": {
-          "ctrl-a ctrl-b": "test:multi-keystroke-command",
-        },
-      })
-      contextMenu.clear()
+    it('does not add accelerators for multi-keystroke key bindings', function() {
+      atom.keymaps.add('source', {
+        '.child': {
+          'ctrl-a ctrl-b': 'test:multi-keystroke-command'
+        }
+      });
+      contextMenu.clear();
       contextMenu.add({
-        ".parent": [
+        '.parent': [
           {
-            label: "Multi-keystroke command",
-            command: "test:multi-keystroke-command",
-          },
-        ],
-      })
+            label: 'Multi-keystroke command',
+            command: 'test:multi-keystroke-command'
+          }
+        ]
+      });
 
-      child.focus()
+      child.focus();
 
-      const label = process.platform === "darwin" ? "⌃A ⌃B" : "Ctrl+A Ctrl+B"
-      expect(contextMenu.templateForEvent({target: child})).toEqual([
+      const label = process.platform === 'darwin' ? '⌃A ⌃B' : 'Ctrl+A Ctrl+B';
+      expect(contextMenu.templateForEvent({ target: child })).toEqual([
         {
           label: `Multi-keystroke command [${label}]`,
           id: `Multi-keystroke command`,
-          command: "test:multi-keystroke-command",
-        },
-      ])
-    })
-  })
+          command: 'test:multi-keystroke-command'
+        }
+      ]);
+    });
+  });
 
-  describe("::templateForEvent(target) (sorting)", function () {
-    it("applies simple sorting rules", function () {
+  describe('::templateForEvent(target) (sorting)', function() {
+    it('applies simple sorting rules', function() {
       contextMenu.add({
-        ".parent": [
+        '.parent': [
           {
-            label: "My Command",
-            command: "test:my-command",
-            after: ["test:my-other-command"],
+            label: 'My Command',
+            command: 'test:my-command',
+            after: ['test:my-other-command']
           },
           {
-            label: "My Other Command",
-            command: "test:my-other-command",
-          },
-        ],
-      })
-      const dispatchedEvent = {target: parent}
+            label: 'My Other Command',
+            command: 'test:my-other-command'
+          }
+        ]
+      });
+      const dispatchedEvent = { target: parent };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: "My Other Command",
-          id: "My Other Command",
-          command: "test:my-other-command",
+          label: 'My Other Command',
+          id: 'My Other Command',
+          command: 'test:my-other-command'
         },
         {
-          label: "My Command",
-          id: "My Command",
-          command: "test:my-command",
-          after: ["test:my-other-command"],
-        },
-      ])
-    })
+          label: 'My Command',
+          id: 'My Command',
+          command: 'test:my-command',
+          after: ['test:my-other-command']
+        }
+      ]);
+    });
 
-    it("applies sorting rules recursively to submenus", function () {
+    it('applies sorting rules recursively to submenus', function() {
       contextMenu.add({
-        ".parent": [
+        '.parent': [
           {
-            label: "Parent",
+            label: 'Parent',
             submenu: [
               {
-                label: "My Command",
-                command: "test:my-command",
-                after: ["test:my-other-command"],
+                label: 'My Command',
+                command: 'test:my-command',
+                after: ['test:my-other-command']
               },
               {
-                label: "My Other Command",
-                command: "test:my-other-command",
-              },
-            ],
-          },
-        ],
-      })
-      const dispatchedEvent = {target: parent}
+                label: 'My Other Command',
+                command: 'test:my-other-command'
+              }
+            ]
+          }
+        ]
+      });
+      const dispatchedEvent = { target: parent };
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([
         {
-          label: "Parent",
+          label: 'Parent',
           id: `Parent`,
           submenu: [
             {
-              label: "My Other Command",
-              id: "My Other Command",
-              command: "test:my-other-command",
+              label: 'My Other Command',
+              id: 'My Other Command',
+              command: 'test:my-other-command'
             },
             {
-              label: "My Command",
-              id: "My Command",
-              command: "test:my-command",
-              after: ["test:my-other-command"],
-            },
-          ],
-        },
-      ])
-    })
-  })
-})
+              label: 'My Command',
+              id: 'My Command',
+              command: 'test:my-command',
+              after: ['test:my-other-command']
+            }
+          ]
+        }
+      ]);
+    });
+  });
+});

--- a/spec/menu-manager-spec.js
+++ b/spec/menu-manager-spec.js
@@ -19,7 +19,7 @@ describe('MenuManager', function() {
         { label: 'A', submenu: [{ label: 'B', command: 'b' }] }
       ]);
       expect(menu.template).toEqual([
-        { label: 'A', submenu: [{ label: 'B', command: 'b' }] }
+        { label: 'A', id : 'A', submenu: [{ label: 'B', id : 'B', command: 'b' }] }
       ]);
       disposable.dispose();
       expect(menu.template).toEqual([]);
@@ -44,14 +44,16 @@ describe('MenuManager', function() {
 
       expect(menu.template).toEqual([
         {
-          label: 'A',
+          label: 'A', 
+          id : 'A',
           submenu: [
-            { label: 'B', command: 'b' },
+            { label: 'B', id : 'B', command: 'b' },
             {
               label: 'C',
+              id: 'C',
               submenu: [
-                { label: 'D', command: 'd' },
-                { label: 'E', command: 'e' }
+                { label: 'D', id: 'D', command: 'd' },
+                { label: 'E', id: 'E', command: 'e' }
               ]
             }
           ]
@@ -61,17 +63,19 @@ describe('MenuManager', function() {
       disposable3.dispose();
       expect(menu.template).toEqual([
         {
-          label: 'A',
+          label: 'A', 
+          id: 'A',
           submenu: [
-            { label: 'B', command: 'b' },
-            { label: 'C', submenu: [{ label: 'D', command: 'd' }] }
+            { label: 'B', id: 'B', command: 'b' },
+            { label: 'C', id: 'C',  
+            submenu: [{ label: 'D', id: 'D', command: 'd' }] }
           ]
         }
       ]);
 
       disposable2.dispose();
       expect(menu.template).toEqual([
-        { label: 'A', submenu: [{ label: 'B', command: 'b' }] }
+        { label: 'A', id: 'A', submenu: [{ label: 'B', id: 'B', command: 'b' }] }
       ]);
 
       disposable1.dispose();
@@ -84,7 +88,8 @@ describe('MenuManager', function() {
       menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
       expect(menu.template[originalItemCount]).toEqual({
         label: 'A',
-        submenu: [{ label: 'B', command: 'b' }]
+        id: 'A',
+        submenu: [{ label: 'B', id: 'B', command: 'b' }]
       });
     });
   });

--- a/spec/menu-manager-spec.js
+++ b/spec/menu-manager-spec.js
@@ -1,195 +1,171 @@
-const path = require('path');
-const MenuManager = require('../src/menu-manager');
+const path = require("path")
+const MenuManager = require("../src/menu-manager")
 
-describe('MenuManager', function() {
-  let menu = null;
+describe("MenuManager", function () {
+  let menu = null
 
-  beforeEach(function() {
+  beforeEach(function () {
     menu = new MenuManager({
       keymapManager: atom.keymaps,
-      packageManager: atom.packages
-    });
-    spyOn(menu, 'sendToBrowserProcess'); // Do not modify Atom's actual menus
-    menu.initialize({ resourcePath: atom.getLoadSettings().resourcePath });
-  });
+      packageManager: atom.packages,
+    })
+    spyOn(menu, "sendToBrowserProcess") // Do not modify Atom's actual menus
+    menu.initialize({resourcePath: atom.getLoadSettings().resourcePath})
+  })
 
-  describe('::add(items)', function() {
-    it('can add new menus that can be removed with the returned disposable', function() {
-      const disposable = menu.add([
-        { label: 'A', submenu: [{ label: 'B', command: 'b' }] }
-      ]);
-      expect(menu.template).toEqual([
-        { label: 'A', id : 'A', submenu: [{ label: 'B', id : 'B', command: 'b' }] }
-      ]);
-      disposable.dispose();
-      expect(menu.template).toEqual([]);
-    });
+  describe("::add(items)", function () {
+    it("can add new menus that can be removed with the returned disposable", function () {
+      const disposable = menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
+      expect(menu.template).toEqual([{label: "A", id: "A", submenu: [{label: "B", id: "B", command: "b"}]}])
+      disposable.dispose()
+      expect(menu.template).toEqual([])
+    })
 
-    it('can add submenu items to existing menus that can be removed with the returned disposable', function() {
-      const disposable1 = menu.add([
-        { label: 'A', submenu: [{ label: 'B', command: 'b' }] }
-      ]);
+    it("can add submenu items to existing menus that can be removed with the returned disposable", function () {
+      const disposable1 = menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
       const disposable2 = menu.add([
         {
-          label: 'A',
-          submenu: [{ label: 'C', submenu: [{ label: 'D', command: 'd' }] }]
-        }
-      ]);
+          label: "A",
+          submenu: [{label: "C", submenu: [{label: "D", command: "d"}]}],
+        },
+      ])
       const disposable3 = menu.add([
         {
-          label: 'A',
-          submenu: [{ label: 'C', submenu: [{ label: 'E', command: 'e' }] }]
-        }
-      ]);
+          label: "A",
+          submenu: [{label: "C", submenu: [{label: "E", command: "e"}]}],
+        },
+      ])
 
       expect(menu.template).toEqual([
         {
-          label: 'A', 
-          id : 'A',
+          label: "A",
+          id: "A",
           submenu: [
-            { label: 'B', id : 'B', command: 'b' },
+            {label: "B", id: "B", command: "b"},
             {
-              label: 'C',
-              id: 'C',
+              label: "C",
+              id: "C",
               submenu: [
-                { label: 'D', id: 'D', command: 'd' },
-                { label: 'E', id: 'E', command: 'e' }
-              ]
-            }
-          ]
-        }
-      ]);
+                {label: "D", id: "D", command: "d"},
+                {label: "E", id: "E", command: "e"},
+              ],
+            },
+          ],
+        },
+      ])
 
-      disposable3.dispose();
+      disposable3.dispose()
       expect(menu.template).toEqual([
         {
-          label: 'A', 
-          id: 'A',
+          label: "A",
+          id: "A",
           submenu: [
-            { label: 'B', id: 'B', command: 'b' },
-            { label: 'C', id: 'C',  
-            submenu: [{ label: 'D', id: 'D', command: 'd' }] }
-          ]
-        }
-      ]);
+            {label: "B", id: "B", command: "b"},
+            {label: "C", id: "C", submenu: [{label: "D", id: "D", command: "d"}]},
+          ],
+        },
+      ])
 
-      disposable2.dispose();
-      expect(menu.template).toEqual([
-        { label: 'A', id: 'A', submenu: [{ label: 'B', id: 'B', command: 'b' }] }
-      ]);
+      disposable2.dispose()
+      expect(menu.template).toEqual([{label: "A", id: "A", submenu: [{label: "B", id: "B", command: "b"}]}])
 
-      disposable1.dispose();
-      expect(menu.template).toEqual([]);
-    });
+      disposable1.dispose()
+      expect(menu.template).toEqual([])
+    })
 
-    it('does not add duplicate labels to the same menu', function() {
-      const originalItemCount = menu.template.length;
-      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
-      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
+    it("does not add duplicate labels to the same menu", function () {
+      const originalItemCount = menu.template.length
+      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
+      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
       expect(menu.template[originalItemCount]).toEqual({
-        label: 'A',
-        id: 'A',
-        submenu: [{ label: 'B', id: 'B', command: 'b' }]
-      });
-    });
-  });
+        label: "A",
+        id: "A",
+        submenu: [{label: "B", id: "B", command: "b"}],
+      })
+    })
+  })
 
-  describe('::update()', function() {
-    const originalPlatform = process.platform;
-    afterEach(() =>
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
-    );
+  describe("::update()", function () {
+    const originalPlatform = process.platform
+    afterEach(() => Object.defineProperty(process, "platform", {value: originalPlatform}))
 
-    it('sends the current menu template and associated key bindings to the browser process', function() {
-      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
-      atom.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
-      menu.update();
-      advanceClock(1);
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toEqual([
-        'ctrl-b'
-      ]);
-    });
+    it("sends the current menu template and associated key bindings to the browser process", function () {
+      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
+      atom.keymaps.add("test", {"atom-workspace": {"ctrl-b": "b"}})
+      menu.update()
+      advanceClock(1)
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toEqual(["ctrl-b"])
+    })
 
-    it('omits key bindings that are mapped to unset! in any context', function() {
+    it("omits key bindings that are mapped to unset! in any context", function () {
       // it would be nice to be smarter about omitting, but that would require a much
       // more dynamic interaction between the currently focused element and the menu
-      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
-      atom.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
-      atom.keymaps.add('test', { 'atom-text-editor': { 'ctrl-b': 'unset!' } });
-      advanceClock(1);
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined();
-    });
+      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
+      atom.keymaps.add("test", {"atom-workspace": {"ctrl-b": "b"}})
+      atom.keymaps.add("test", {"atom-text-editor": {"ctrl-b": "unset!"}})
+      advanceClock(1)
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toBeUndefined()
+    })
 
-    it('omits key bindings that could conflict with AltGraph characters on macOS', function() {
-      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    it("omits key bindings that could conflict with AltGraph characters on macOS", function () {
+      Object.defineProperty(process, "platform", {value: "darwin"})
       menu.add([
         {
-          label: 'A',
+          label: "A",
           submenu: [
-            { label: 'B', command: 'b' },
-            { label: 'C', command: 'c' },
-            { label: 'D', command: 'd' }
-          ]
-        }
-      ]);
+            {label: "B", command: "b"},
+            {label: "C", command: "c"},
+            {label: "D", command: "d"},
+          ],
+        },
+      ])
 
-      atom.keymaps.add('test', {
-        'atom-workspace': {
-          'alt-b': 'b',
-          'alt-shift-C': 'c',
-          'alt-cmd-d': 'd'
-        }
-      });
+      atom.keymaps.add("test", {
+        "atom-workspace": {
+          "alt-b": "b",
+          "alt-shift-C": "c",
+          "alt-cmd-d": "d",
+        },
+      })
 
-      advanceClock(1);
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined();
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['c']).toBeUndefined();
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['d']).toEqual([
-        'alt-cmd-d'
-      ]);
-    });
+      advanceClock(1)
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toBeUndefined()
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["c"]).toBeUndefined()
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["d"]).toEqual(["alt-cmd-d"])
+    })
 
-    it('omits key bindings that could conflict with AltGraph characters on Windows', function() {
-      Object.defineProperty(process, 'platform', { value: 'win32' });
+    it("omits key bindings that could conflict with AltGraph characters on Windows", function () {
+      Object.defineProperty(process, "platform", {value: "win32"})
       menu.add([
         {
-          label: 'A',
+          label: "A",
           submenu: [
-            { label: 'B', command: 'b' },
-            { label: 'C', command: 'c' },
-            { label: 'D', command: 'd' }
-          ]
-        }
-      ]);
+            {label: "B", command: "b"},
+            {label: "C", command: "c"},
+            {label: "D", command: "d"},
+          ],
+        },
+      ])
 
-      atom.keymaps.add('test', {
-        'atom-workspace': {
-          'ctrl-alt-b': 'b',
-          'ctrl-alt-shift-C': 'c',
-          'ctrl-alt-cmd-d': 'd'
-        }
-      });
+      atom.keymaps.add("test", {
+        "atom-workspace": {
+          "ctrl-alt-b": "b",
+          "ctrl-alt-shift-C": "c",
+          "ctrl-alt-cmd-d": "d",
+        },
+      })
 
-      advanceClock(1);
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined();
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['c']).toBeUndefined();
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]['d']).toEqual([
-        'ctrl-alt-cmd-d'
-      ]);
-    });
-  });
+      advanceClock(1)
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toBeUndefined()
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["c"]).toBeUndefined()
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]["d"]).toEqual(["ctrl-alt-cmd-d"])
+    })
+  })
 
-  it('updates the application menu when a keymap is reloaded', function() {
-    spyOn(menu, 'update');
-    const keymapPath = path.join(
-      __dirname,
-      'fixtures',
-      'packages',
-      'package-with-keymaps',
-      'keymaps',
-      'keymap-1.cson'
-    );
-    atom.keymaps.reloadKeymap(keymapPath);
-    expect(menu.update).toHaveBeenCalled();
-  });
-});
+  it("updates the application menu when a keymap is reloaded", function () {
+    spyOn(menu, "update")
+    const keymapPath = path.join(__dirname, "fixtures", "packages", "package-with-keymaps", "keymaps", "keymap-1.cson")
+    atom.keymaps.reloadKeymap(keymapPath)
+    expect(menu.update).toHaveBeenCalled()
+  })
+})

--- a/spec/menu-manager-spec.js
+++ b/spec/menu-manager-spec.js
@@ -1,171 +1,206 @@
-const path = require("path")
-const MenuManager = require("../src/menu-manager")
+const path = require('path');
+const MenuManager = require('../src/menu-manager');
 
-describe("MenuManager", function () {
-  let menu = null
+describe('MenuManager', function() {
+  let menu = null;
 
-  beforeEach(function () {
+  beforeEach(function() {
     menu = new MenuManager({
       keymapManager: atom.keymaps,
-      packageManager: atom.packages,
-    })
-    spyOn(menu, "sendToBrowserProcess") // Do not modify Atom's actual menus
-    menu.initialize({resourcePath: atom.getLoadSettings().resourcePath})
-  })
+      packageManager: atom.packages
+    });
+    spyOn(menu, 'sendToBrowserProcess'); // Do not modify Atom's actual menus
+    menu.initialize({ resourcePath: atom.getLoadSettings().resourcePath });
+  });
 
-  describe("::add(items)", function () {
-    it("can add new menus that can be removed with the returned disposable", function () {
-      const disposable = menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
-      expect(menu.template).toEqual([{label: "A", id: "A", submenu: [{label: "B", id: "B", command: "b"}]}])
-      disposable.dispose()
-      expect(menu.template).toEqual([])
-    })
+  describe('::add(items)', function() {
+    it('can add new menus that can be removed with the returned disposable', function() {
+      const disposable = menu.add([
+        { label: 'A', submenu: [{ label: 'B', command: 'b' }] }
+      ]);
+      expect(menu.template).toEqual([
+        {
+          label: 'A',
+          id: 'A',
+          submenu: [{ label: 'B', id: 'B', command: 'b' }]
+        }
+      ]);
+      disposable.dispose();
+      expect(menu.template).toEqual([]);
+    });
 
-    it("can add submenu items to existing menus that can be removed with the returned disposable", function () {
-      const disposable1 = menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
+    it('can add submenu items to existing menus that can be removed with the returned disposable', function() {
+      const disposable1 = menu.add([
+        { label: 'A', submenu: [{ label: 'B', command: 'b' }] }
+      ]);
       const disposable2 = menu.add([
         {
-          label: "A",
-          submenu: [{label: "C", submenu: [{label: "D", command: "d"}]}],
-        },
-      ])
+          label: 'A',
+          submenu: [{ label: 'C', submenu: [{ label: 'D', command: 'd' }] }]
+        }
+      ]);
       const disposable3 = menu.add([
         {
-          label: "A",
-          submenu: [{label: "C", submenu: [{label: "E", command: "e"}]}],
-        },
-      ])
+          label: 'A',
+          submenu: [{ label: 'C', submenu: [{ label: 'E', command: 'e' }] }]
+        }
+      ]);
 
       expect(menu.template).toEqual([
         {
-          label: "A",
-          id: "A",
+          label: 'A',
+          id: 'A',
           submenu: [
-            {label: "B", id: "B", command: "b"},
+            { label: 'B', id: 'B', command: 'b' },
             {
-              label: "C",
-              id: "C",
+              label: 'C',
+              id: 'C',
               submenu: [
-                {label: "D", id: "D", command: "d"},
-                {label: "E", id: "E", command: "e"},
-              ],
-            },
-          ],
-        },
-      ])
+                { label: 'D', id: 'D', command: 'd' },
+                { label: 'E', id: 'E', command: 'e' }
+              ]
+            }
+          ]
+        }
+      ]);
 
-      disposable3.dispose()
+      disposable3.dispose();
       expect(menu.template).toEqual([
         {
-          label: "A",
-          id: "A",
+          label: 'A',
+          id: 'A',
           submenu: [
-            {label: "B", id: "B", command: "b"},
-            {label: "C", id: "C", submenu: [{label: "D", id: "D", command: "d"}]},
-          ],
-        },
-      ])
+            { label: 'B', id: 'B', command: 'b' },
+            {
+              label: 'C',
+              id: 'C',
+              submenu: [{ label: 'D', id: 'D', command: 'd' }]
+            }
+          ]
+        }
+      ]);
 
-      disposable2.dispose()
-      expect(menu.template).toEqual([{label: "A", id: "A", submenu: [{label: "B", id: "B", command: "b"}]}])
+      disposable2.dispose();
+      expect(menu.template).toEqual([
+        {
+          label: 'A',
+          id: 'A',
+          submenu: [{ label: 'B', id: 'B', command: 'b' }]
+        }
+      ]);
 
-      disposable1.dispose()
-      expect(menu.template).toEqual([])
-    })
+      disposable1.dispose();
+      expect(menu.template).toEqual([]);
+    });
 
-    it("does not add duplicate labels to the same menu", function () {
-      const originalItemCount = menu.template.length
-      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
-      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
+    it('does not add duplicate labels to the same menu', function() {
+      const originalItemCount = menu.template.length;
+      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
+      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
       expect(menu.template[originalItemCount]).toEqual({
-        label: "A",
-        id: "A",
-        submenu: [{label: "B", id: "B", command: "b"}],
-      })
-    })
-  })
+        label: 'A',
+        id: 'A',
+        submenu: [{ label: 'B', id: 'B', command: 'b' }]
+      });
+    });
+  });
 
-  describe("::update()", function () {
-    const originalPlatform = process.platform
-    afterEach(() => Object.defineProperty(process, "platform", {value: originalPlatform}))
+  describe('::update()', function() {
+    const originalPlatform = process.platform;
+    afterEach(() =>
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    );
 
-    it("sends the current menu template and associated key bindings to the browser process", function () {
-      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
-      atom.keymaps.add("test", {"atom-workspace": {"ctrl-b": "b"}})
-      menu.update()
-      advanceClock(1)
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toEqual(["ctrl-b"])
-    })
+    it('sends the current menu template and associated key bindings to the browser process', function() {
+      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
+      atom.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
+      menu.update();
+      advanceClock(1);
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toEqual([
+        'ctrl-b'
+      ]);
+    });
 
-    it("omits key bindings that are mapped to unset! in any context", function () {
+    it('omits key bindings that are mapped to unset! in any context', function() {
       // it would be nice to be smarter about omitting, but that would require a much
       // more dynamic interaction between the currently focused element and the menu
-      menu.add([{label: "A", submenu: [{label: "B", command: "b"}]}])
-      atom.keymaps.add("test", {"atom-workspace": {"ctrl-b": "b"}})
-      atom.keymaps.add("test", {"atom-text-editor": {"ctrl-b": "unset!"}})
-      advanceClock(1)
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toBeUndefined()
-    })
+      menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
+      atom.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
+      atom.keymaps.add('test', { 'atom-text-editor': { 'ctrl-b': 'unset!' } });
+      advanceClock(1);
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined();
+    });
 
-    it("omits key bindings that could conflict with AltGraph characters on macOS", function () {
-      Object.defineProperty(process, "platform", {value: "darwin"})
+    it('omits key bindings that could conflict with AltGraph characters on macOS', function() {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
       menu.add([
         {
-          label: "A",
+          label: 'A',
           submenu: [
-            {label: "B", command: "b"},
-            {label: "C", command: "c"},
-            {label: "D", command: "d"},
-          ],
-        },
-      ])
+            { label: 'B', command: 'b' },
+            { label: 'C', command: 'c' },
+            { label: 'D', command: 'd' }
+          ]
+        }
+      ]);
 
-      atom.keymaps.add("test", {
-        "atom-workspace": {
-          "alt-b": "b",
-          "alt-shift-C": "c",
-          "alt-cmd-d": "d",
-        },
-      })
+      atom.keymaps.add('test', {
+        'atom-workspace': {
+          'alt-b': 'b',
+          'alt-shift-C': 'c',
+          'alt-cmd-d': 'd'
+        }
+      });
 
-      advanceClock(1)
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toBeUndefined()
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["c"]).toBeUndefined()
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["d"]).toEqual(["alt-cmd-d"])
-    })
+      advanceClock(1);
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined();
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['c']).toBeUndefined();
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['d']).toEqual([
+        'alt-cmd-d'
+      ]);
+    });
 
-    it("omits key bindings that could conflict with AltGraph characters on Windows", function () {
-      Object.defineProperty(process, "platform", {value: "win32"})
+    it('omits key bindings that could conflict with AltGraph characters on Windows', function() {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
       menu.add([
         {
-          label: "A",
+          label: 'A',
           submenu: [
-            {label: "B", command: "b"},
-            {label: "C", command: "c"},
-            {label: "D", command: "d"},
-          ],
-        },
-      ])
+            { label: 'B', command: 'b' },
+            { label: 'C', command: 'c' },
+            { label: 'D', command: 'd' }
+          ]
+        }
+      ]);
 
-      atom.keymaps.add("test", {
-        "atom-workspace": {
-          "ctrl-alt-b": "b",
-          "ctrl-alt-shift-C": "c",
-          "ctrl-alt-cmd-d": "d",
-        },
-      })
+      atom.keymaps.add('test', {
+        'atom-workspace': {
+          'ctrl-alt-b': 'b',
+          'ctrl-alt-shift-C': 'c',
+          'ctrl-alt-cmd-d': 'd'
+        }
+      });
 
-      advanceClock(1)
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["b"]).toBeUndefined()
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["c"]).toBeUndefined()
-      expect(menu.sendToBrowserProcess.argsForCall[0][1]["d"]).toEqual(["ctrl-alt-cmd-d"])
-    })
-  })
+      advanceClock(1);
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined();
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['c']).toBeUndefined();
+      expect(menu.sendToBrowserProcess.argsForCall[0][1]['d']).toEqual([
+        'ctrl-alt-cmd-d'
+      ]);
+    });
+  });
 
-  it("updates the application menu when a keymap is reloaded", function () {
-    spyOn(menu, "update")
-    const keymapPath = path.join(__dirname, "fixtures", "packages", "package-with-keymaps", "keymaps", "keymap-1.cson")
-    atom.keymaps.reloadKeymap(keymapPath)
-    expect(menu.update).toHaveBeenCalled()
-  })
-})
+  it('updates the application menu when a keymap is reloaded', function() {
+    spyOn(menu, 'update');
+    const keymapPath = path.join(
+      __dirname,
+      'fixtures',
+      'packages',
+      'package-with-keymaps',
+      'keymaps',
+      'keymap-1.cson'
+    );
+    atom.keymaps.reloadKeymap(keymapPath);
+    expect(menu.update).toHaveBeenCalled();
+  });
+});

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -109,6 +109,9 @@ class ContextMenuManager
   #     with the following argument:
   #     * `event` The click event that deployed the context menu.
   #
+  #   * `id` (internal) The {String} menu id, which is used only in javascript code, is not used in menu template.
+  #     For further information on the `id`, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
+  #
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added menu items.
   add: (itemsBySelector, throwOnInvalidSelector = true) ->

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -109,9 +109,7 @@ class ContextMenuManager
   #     with the following argument:
   #     * `event` The click event that deployed the context menu.
   #
-  #   * `id` (internal) The {String} menu id, which is used only in javascript code, is not used in menu template.
-  #     For further information on the `id`, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
-  #
+  #   * `id` (internal) A {String} containing the menu item's id.
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added menu items.
   add: (itemsBySelector, throwOnInvalidSelector = true) ->

--- a/src/main-process/application-menu.js
+++ b/src/main-process/application-menu.js
@@ -124,7 +124,6 @@ module.exports = class ApplicationMenu {
       ({ id }) => id === 'Downloading Update'
     );
     const installUpdateItem = items.find(
-      // ({ label }) => label === 'Restart and Install Update'
       ({ id }) => id === 'Restart and Install Update'
     );
 

--- a/src/main-process/application-menu.js
+++ b/src/main-process/application-menu.js
@@ -121,7 +121,6 @@ module.exports = class ApplicationMenu {
       ({ id }) => id === 'Checking for Update'
     );
     const downloadingUpdateItem = items.find(
-      // ({ label }) => label === 'Downloading Update'
       ({ id }) => id === 'Downloading Update'
     );
     const installUpdateItem = items.find(

--- a/src/main-process/application-menu.js
+++ b/src/main-process/application-menu.js
@@ -115,16 +115,20 @@ module.exports = class ApplicationMenu {
   showUpdateMenuItem(state) {
     const items = this.flattenMenuItems(this.menu);
     const checkForUpdateItem = items.find(
-      ({ label }) => label === 'Check for Update'
+      // ({ label }) => label === 'Check for Update'
+      ({ id }) => id === 'Check for Update'
     );
     const checkingForUpdateItem = items.find(
-      ({ label }) => label === 'Checking for Update'
+      // ({ label }) => label === 'Checking for Update'
+      ({ id }) => id === 'Checking for Update'
     );
     const downloadingUpdateItem = items.find(
-      ({ label }) => label === 'Downloading Update'
+      // ({ label }) => label === 'Downloading Update'
+      ({ id }) => id === 'Downloading Update'
     );
     const installUpdateItem = items.find(
-      ({ label }) => label === 'Restart and Install Update'
+      // ({ label }) => label === 'Restart and Install Update'
+      ({ id }) => id === 'Restart and Install Update'
     );
 
     if (
@@ -165,13 +169,16 @@ module.exports = class ApplicationMenu {
     return [
       {
         label: 'Atom',
+        id: 'Atom',
         submenu: [
           {
             label: 'Check for Update',
+            id: 'Check for Update',
             metadata: { autoUpdate: true }
           },
           {
             label: 'Reload',
+            id: 'Reload',
             accelerator: 'Command+R',
             click: () => {
               const window = this.focusedWindow();
@@ -180,6 +187,7 @@ module.exports = class ApplicationMenu {
           },
           {
             label: 'Close Window',
+            id: 'Close Window',
             accelerator: 'Command+Shift+W',
             click: () => {
               const window = this.focusedWindow();
@@ -188,6 +196,7 @@ module.exports = class ApplicationMenu {
           },
           {
             label: 'Toggle Dev Tools',
+            id: 'Toggle Dev Tools',
             accelerator: 'Command+Alt+I',
             click: () => {
               const window = this.focusedWindow();
@@ -196,6 +205,7 @@ module.exports = class ApplicationMenu {
           },
           {
             label: 'Quit',
+            id: 'Quit',
             accelerator: 'Command+Q',
             click: () => app.quit()
           }

--- a/src/main-process/application-menu.js
+++ b/src/main-process/application-menu.js
@@ -115,7 +115,6 @@ module.exports = class ApplicationMenu {
   showUpdateMenuItem(state) {
     const items = this.flattenMenuItems(this.menu);
     const checkForUpdateItem = items.find(
-      // ({ label }) => label === 'Check for Update'
       ({ id }) => id === 'Check for Update'
     );
     const checkingForUpdateItem = items.find(

--- a/src/main-process/application-menu.js
+++ b/src/main-process/application-menu.js
@@ -118,7 +118,6 @@ module.exports = class ApplicationMenu {
       ({ id }) => id === 'Check for Update'
     );
     const checkingForUpdateItem = items.find(
-      // ({ label }) => label === 'Checking for Update'
       ({ id }) => id === 'Checking for Update'
     );
     const downloadingUpdateItem = items.find(

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -36,6 +36,7 @@ function merge(menu, item, itemSpecificity = Infinity) {
 }
 
 function unmerge(menu, item) {
+  item = cloneMenuItem(item);
   const matchingItemIndex = findMatchingItemIndex(menu, item);
   if (matchingItemIndex === -1) {
     return;
@@ -83,7 +84,7 @@ function cloneMenuItem(item) {
     item,
     'type',
     'label',
-    'id',            // added for atom-i18n package, and used only internal.
+    'id',
     'enabled',
     'visible',
     'command',
@@ -99,7 +100,7 @@ function cloneMenuItem(item) {
   if (item.id === null || item.id === undefined) {
     // item.id is internally used by the function defined in this file, because `atom-i18n` localize item.label.
     // cloneMenuItem() create menus from template (menu_{darwin, linux, win32}.cson), then `atom-i18n` can localize menu.
-    item.id = normalizeLabel(item.label)
+    item.id = normalizeLabel(item.label);
   }
   if (item.submenu != null) {
     item.submenu = item.submenu.map(submenuItem => cloneMenuItem(submenuItem));

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -83,6 +83,7 @@ function cloneMenuItem(item) {
     item,
     'type',
     'label',
+    'id',            // added for atom-i18n package, and used only internal.
     'enabled',
     'visible',
     'command',
@@ -95,7 +96,11 @@ function cloneMenuItem(item) {
     'beforeGroupContaining',
     'afterGroupContaining'
   );
-  if (item.id === null || item.id === undefined) { item.id = normalizeLabel(item.label) }
+  if (item.id === null || item.id === undefined) {
+    // item.id is internally used by the function defined in this file, because `atom-i18n` localize item.label.
+    // cloneMenuItem() create menus from template (menu_{darwin, linux, win32}.cson), then `atom-i18n` can localize menu.
+    item.id = normalizeLabel(item.label)
+  }
   if (item.submenu != null) {
     item.submenu = item.submenu.map(submenuItem => cloneMenuItem(submenuItem));
   }

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -96,8 +96,6 @@ function cloneMenuItem(item) {
     'afterGroupContaining'
   );
   if (item.id === null || item.id === undefined) {
-    // item.id is internally used by the function defined in this file, because `atom-i18n` localize item.label.
-    // cloneMenuItem() create menus from template (menu_{darwin, linux, win32}.cson), then `atom-i18n` can localize menu.
     item.id = normalizeLabel(item.label);
   }
   if (item.submenu != null) {

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -53,14 +53,16 @@ function unmerge(menu, item) {
   }
 }
 
-function findMatchingItemIndex(menu, { type, label, submenu }) {
+// function findMatchingItemIndex(menu, { type, label, submenu }) {
+function findMatchingItemIndex(menu, { type, id, submenu }) {
   if (type === 'separator') {
     return -1;
   }
   for (let index = 0; index < menu.length; index++) {
     const item = menu[index];
     if (
-      normalizeLabel(item.label) === normalizeLabel(label) &&
+      // normalizeLabel(item.label) === normalizeLabel(label) &&
+      item.id === id &&
       (item.submenu != null) === (submenu != null)
     ) {
       return index;
@@ -93,6 +95,7 @@ function cloneMenuItem(item) {
     'beforeGroupContaining',
     'afterGroupContaining'
   );
+  if (item.id === null || item.id === undefined) { item.id = normalizeLabel(item.label) }
   if (item.submenu != null) {
     item.submenu = item.submenu.map(submenuItem => cloneMenuItem(submenuItem));
   }

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -61,7 +61,6 @@ function findMatchingItemIndex(menu, { type, id, submenu }) {
   for (let index = 0; index < menu.length; index++) {
     const item = menu[index];
     if (
-      // normalizeLabel(item.label) === normalizeLabel(label) &&
       item.id === id &&
       (item.submenu != null) === (submenu != null)
     ) {

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -54,7 +54,6 @@ function unmerge(menu, item) {
   }
 }
 
-// function findMatchingItemIndex(menu, { type, label, submenu }) {
 function findMatchingItemIndex(menu, { type, id, submenu }) {
   if (type === 'separator') {
     return -1;

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -60,9 +60,7 @@ function findMatchingItemIndex(menu, { type, id, submenu }) {
   }
   for (let index = 0; index < menu.length; index++) {
     const item = menu[index];
-    if (
-      item.id === id && (item.submenu != null) === (submenu != null)
-    ) {
+    if (item.id === id && (item.submenu != null) === (submenu != null)) {
       return index;
     }
   }

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -61,8 +61,7 @@ function findMatchingItemIndex(menu, { type, id, submenu }) {
   for (let index = 0; index < menu.length; index++) {
     const item = menu[index];
     if (
-      item.id === id &&
-      (item.submenu != null) === (submenu != null)
+      item.id === id && (item.submenu != null) === (submenu != null)
     ) {
       return index;
     }

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -78,17 +78,20 @@ class MenuManager
   #   atom.menu.add [
   #     {
   #       label: 'Hello'
-  #       submenu : [{label: 'World!', command: 'hello:world'}]
+  #       submenu : [{label: 'World!', id: 'World!', command: 'hello:world'}]
   #     }
   #   ]
   # ```
   #
   # * `items` An {Array} of menu item {Object}s containing the keys:
-  #   * `label` The {String} menu label.
+  #   * `label` The {String} menu label, which is used for localiztion (in `atom-i18n` package).
   #   * `submenu` An optional {Array} of sub menu items.
   #   * `command` An optional {String} command to trigger when the item is
   #     clicked.
   #
+  #   * `id` (internal) The {String} menu id, which is used only in javascript code, is not used in menu template. 
+  # For further information on the above args, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
+  # 
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added menu items.
   add: (items) ->
@@ -201,7 +204,8 @@ class MenuManager
       []
 
   sortPackagesMenu: ->
-    packagesMenu = _.find @template, ({label}) -> MenuHelpers.normalizeLabel(label) is 'Packages'
+    # packagesMenu = _.find @template, ({label}) -> MenuHelpers.normalizeLabel(label) is 'Packages'
+    packagesMenu = _.find @template, ({id}) -> MenuHelpers.normalizeLabel(id) is 'Packages'
     return unless packagesMenu?.submenu?
 
     packagesMenu.submenu.sort (item1, item2) ->

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -90,8 +90,6 @@ class MenuManager
   #     clicked.
   #
   #   * `id` (internal) A {String} containing the menu item's id.
-  #     For further information on the `id`, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
-  #
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added menu items.
   add: (items) ->

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -89,7 +89,7 @@ class MenuManager
   #   * `command` An optional {String} command to trigger when the item is
   #     clicked.
   #
-  #   * `id` (internal) The {String} menu id, which is used only in javascript code, is not used in menu template.
+  #   * `id` (internal) The {String} menu id, not used in menu template.
   #     For further information on the `id`, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
   #
   # Returns a {Disposable} on which `.dispose()` can be called to remove the

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -84,7 +84,7 @@ class MenuManager
   # ```
   #
   # * `items` An {Array} of menu item {Object}s containing the keys:
-  #   * `label` The {String} menu label, which is used for localiztion (in `atom-i18n` package).
+  #   * `label` The {String} menu label.
   #   * `submenu` An optional {Array} of sub menu items.
   #   * `command` An optional {String} command to trigger when the item is
   #     clicked.

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -202,7 +202,6 @@ class MenuManager
       []
 
   sortPackagesMenu: ->
-    # packagesMenu = _.find @template, ({label}) -> MenuHelpers.normalizeLabel(label) is 'Packages'
     packagesMenu = _.find @template, ({id}) -> MenuHelpers.normalizeLabel(id) is 'Packages'
     return unless packagesMenu?.submenu?
 

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -89,9 +89,9 @@ class MenuManager
   #   * `command` An optional {String} command to trigger when the item is
   #     clicked.
   #
-  #   * `id` (internal) The {String} menu id, which is used only in javascript code, is not used in menu template. 
-  # For further information on the above args, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
-  # 
+  #   * `id` (internal) The {String} menu id, which is used only in javascript code, is not used in menu template.
+  #     For further information on the `id`, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
+  #
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added menu items.
   add: (items) ->

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -89,7 +89,7 @@ class MenuManager
   #   * `command` An optional {String} command to trigger when the item is
   #     clicked.
   #
-  #   * `id` (internal) The {String} menu id, not used in menu template.
+  #   * `id` (internal) A {String} containing the menu item's id.
   #     For further information on the `id`, see [Electron MenuItem](https://www.electronjs.org/docs/api/menu-item#class-menuitem)).
   #
   # Returns a {Disposable} on which `.dispose()` can be called to remove the

--- a/src/reopen-project-menu-manager.js
+++ b/src/reopen-project-menu-manager.js
@@ -146,9 +146,11 @@ module.exports = class ReopenProjectMenuManager {
   static createProjectsMenu(projects) {
     return {
       label: 'File',
+      id: 'File',
       submenu: [
         {
           label: 'Reopen Project',
+          id: 'Reopen Project',
           submenu: projects.map((project, index) => ({
             label: this.createLabel(project),
             command: 'application:reopen-project',


### PR DESCRIPTION

### Identify the Bug

Issue [#22594](https://github.com/atom/atom/issues/22594)

### Description of the Change

In regard to MenuManager.add(items) in atom/src/menu-manager.coffee.

Atom Core and [`atom-i18n`](https://github.com/liuderchi/atom-i18n) package use the same `label` member of the argument items, 
which is mentioned above.
After `atom-i18n` localize menus and submenus, Atom Core can not update them correctly.

So, I added the class member `id` to the argument `items`, which means a member of class MenuItem in Electron.
After `atom-i18n` localize `label`, Atom Core use `id` (instead of `label`, which is current implementation) to update menus and submenus.

#### Modified files

1. atom/src/menu-helpers.js
2. atom/src/menu-manager.coffee
3. atom/src/reopen-project-menu-manager.js
4. atom/src/main-process/application-menu.js


### Alternate Designs

I used `sublabel` instead of `id`. But strings of `sublabel` appear under the strings of `label`.

### Possible Drawbacks

1. The menus, which are created from menus/*.cson, of Atom Core and other packages are not updated correctly.
2. I have not yet create specs files, because I need to study how to write specs.
3. I tested on only Windows. This fix should be verified on Linux and macOS.

### Verification Process

I imported [`atom-i18n`](https://github.com/liuderchi/atom-i18n) package, and set locale to Japanese.
1. The menubar has "ファイル(F)" and no "File" menu, and "Reopen Project" menu has correct projects.
2. The "ヘルプ(H)" menu has "アップデートを確認", which means "Check for Update".

### Release Notes

When Atom is localized with the atom-i18n package, the "File" menu is no longer added to the menu bar and "Check for Update" is localized and displayed in the "Help" menu on Windows.
<!-- 
atom-i18n パッケージで Atom をローカライズした際、メニューバーに "File" メニューが追加されることがなくなり、Windows の場合に "Help" メニュー に "Check for Update" がローカライズされて表示されます。
-->
