### PR TITLE
Make sure path is not undefined (#20871)

### DIFF
--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -294,8 +294,8 @@ class NSFWNativeWatcher extends NativeWatcher {
           if (event.file) {
             payload.path = path.join(event.directory, event.file);
           } else {
-            payload.oldPath = path.join(event.directory, event.oldFile??'');
-            payload.path = path.join(event.directory, event.newFile??'');
+            payload.oldPath = path.join(event.directory, event.oldFile == undefined ? '' : event.oldFile);
+            payload.path = path.join(event.directory, event.newFile == undefined ? '' : event.newFile);
           }
 
           return payload;

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -296,11 +296,11 @@ class NSFWNativeWatcher extends NativeWatcher {
           } else {
             payload.oldPath = path.join(
               event.directory,
-              (typeof event.oldFile === 'undefined') ? '' : event.oldFile
+              typeof event.oldFile === 'undefined' ? '' : event.oldFile
             );
             payload.path = path.join(
               event.directory, 
-              (typeof event.newFile === 'undefined') ? '' : event.newFile
+              typeof event.newFile === 'undefined' ? '' : event.newFile
             );
           }
 

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -294,8 +294,14 @@ class NSFWNativeWatcher extends NativeWatcher {
           if (event.file) {
             payload.path = path.join(event.directory, event.file);
           } else {
-            payload.oldPath = path.join(event.directory, event.oldFile == undefined ? '' : event.oldFile);
-            payload.path = path.join(event.directory, event.newFile == undefined ? '' : event.newFile);
+            payload.oldPath = path.join(
+              event.directory,
+              (typeof event.oldFile === 'undefined') ? '' : event.oldFile
+            );
+            payload.path = path.join(
+              event.directory, 
+              (typeof event.newFile === 'undefined') ? '' : event.newFile
+            );
           }
 
           return payload;

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -299,7 +299,7 @@ class NSFWNativeWatcher extends NativeWatcher {
               typeof event.oldFile === 'undefined' ? '' : event.oldFile
             );
             payload.path = path.join(
-              event.directory, 
+              event.directory,
               typeof event.newFile === 'undefined' ? '' : event.newFile
             );
           }

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -294,8 +294,8 @@ class NSFWNativeWatcher extends NativeWatcher {
           if (event.file) {
             payload.path = path.join(event.directory, event.file);
           } else {
-            payload.oldPath = path.join(event.directory, event.oldFile);
-            payload.path = path.join(event.directory, event.newFile);
+            payload.oldPath = path.join(event.directory, event.oldFile??'');
+            payload.path = path.join(event.directory, event.newFile??'');
           }
 
           return payload;


### PR DESCRIPTION
### Identify the Bug

This fixes a bug where upating the rights (CHMOD) of files mounted on a SMB share causes the path watcher to create an invalid path (see #20871)

### Description of the Change

While I do not understand the exact origins how this bug comes together, I still managed to provide a very obvious fix for something that should be a string rather than `undefined`.

### Alternate Designs

none

### Possible Drawbacks

none

### Verification Process

Working with files from a SMB share (Windows host) on a daily basis it is as simple as having open a SMB mounted directory and updating the rights of the folder via `chmod -R 775`.

### Release Notes

Fixed an error that occurs when working with files from a SMB share