### PR TITLE
Fixed command to install Atom dependencies on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ but should be compatible with other Linux distributions.
 
 1. Install dependencies (on Ubuntu):
 ```sh
-sudo apt install git libasound2 libcurl libgbm1 libgcrypt20 libgtk-3-0 libnotify4 libnss3 libglib2.0-bin xdg-utils libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxkbfile1
+sudo apt install git libasound2 libcurl4 libgbm1 libgcrypt20 libgtk-3-0 libnotify4 libnss3 libglib2.0-bin xdg-utils libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxkbfile1
 ```
 2. Download `atom-amd64.tar.gz` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
 3. Run `tar xf atom-amd64.tar.gz` in the directory where you want to extract the Atom folder.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ An archive is available for people who don't want to install `atom` as root.
 This version enables you to install multiple Atom versions in parallel. It has been built on Ubuntu 64-bit,
 but should be compatible with other Linux distributions.
 
-1. Install dependencies (on Ubuntu): `sudo apt install git libasound2, libcurl4, libgbm1, libgcrypt20, libgtk-3-0, libnotify4, libnss3, libglib2.0-bin, xdg-utils, libx11-xcb1, libxcb-dri3-0, libxss1, libxtst6, libxkbfile1`
+1. Install dependencies (on Ubuntu): `sudo apt install git libasound2 libcurl libgbm1 libgcrypt20 libgtk-3-0 libnotify4 libnss3 libglib2.0-bin xdg-utils libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxkbfile1`
 2. Download `atom-amd64.tar.gz` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
 3. Run `tar xf atom-amd64.tar.gz` in the directory where you want to extract the Atom folder.
 4. Launch Atom using the installed `atom` command from the newly extracted directory.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,13 @@ An archive is available for people who don't want to install `atom` as root.
 This version enables you to install multiple Atom versions in parallel. It has been built on Ubuntu 64-bit,
 but should be compatible with other Linux distributions.
 
-1. Install dependencies (on Ubuntu): `sudo apt install git libasound2 libcurl libgbm1 libgcrypt20 libgtk-3-0 libnotify4 libnss3 libglib2.0-bin xdg-utils libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxkbfile1`
-2. Download `atom-amd64.tar.gz` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
-3. Run `tar xf atom-amd64.tar.gz` in the directory where you want to extract the Atom folder.
-4. Launch Atom using the installed `atom` command from the newly extracted directory.
+1. Install dependencies (on Ubuntu):
+```sh
+sudo apt install git libasound2 libcurl libgbm1 libgcrypt20 libgtk-3-0 libnotify4 libnss3 libglib2.0-bin xdg-utils libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxkbfile1
+```
+3. Download `atom-amd64.tar.gz` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
+4. Run `tar xf atom-amd64.tar.gz` in the directory where you want to extract the Atom folder.
+5. Launch Atom using the installed `atom` command from the newly extracted directory.
 
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ but should be compatible with other Linux distributions.
 ```sh
 sudo apt install git libasound2 libcurl libgbm1 libgcrypt20 libgtk-3-0 libnotify4 libnss3 libglib2.0-bin xdg-utils libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxkbfile1
 ```
-3. Download `atom-amd64.tar.gz` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
-4. Run `tar xf atom-amd64.tar.gz` in the directory where you want to extract the Atom folder.
-5. Launch Atom using the installed `atom` command from the newly extracted directory.
+2. Download `atom-amd64.tar.gz` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
+3. Run `tar xf atom-amd64.tar.gz` in the directory where you want to extract the Atom folder.
+4. Launch Atom using the installed `atom` command from the newly extracted directory.
 
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.


### PR DESCRIPTION
The current version for installing dependencies on Ubuntu for the prebuilt `.tar.gz` package has some commas in between package names, which causes issues when installing with APT, as can be seen below:

![image](https://user-images.githubusercontent.com/74838472/124572967-b86d2080-de0e-11eb-86dc-6e9d444e368b.png)

The new version removes the commas, as well as puts the command on a separate line, allowing the clipboard button to copy the command to work properly.

-----
[View rendered README.md](https://github.com/hwittenborn/atom/blob/master/README.md)