### PR TITLE
Migrate styles element to custom elements

### DIFF
--- a/spec/styles-element-spec.js
+++ b/spec/styles-element-spec.js
@@ -1,4 +1,4 @@
-const StylesElement = require('../src/styles-element');
+const { createStylesElement } = require('../src/styles-element');
 
 describe('StylesElement', function() {
   let [
@@ -9,7 +9,7 @@ describe('StylesElement', function() {
   ] = [];
 
   beforeEach(function() {
-    element = new StylesElement();
+    element = createStylesElement();
     element.initialize(atom.styles);
     document.querySelector('#jasmine-content').appendChild(element);
     addedStyleElements = [];

--- a/src/style-manager.js
+++ b/src/style-manager.js
@@ -4,7 +4,7 @@ const fs = require('fs-plus');
 const path = require('path');
 const postcss = require('postcss');
 const selectorParser = require('postcss-selector-parser');
-const StylesElement = require('./styles-element');
+const { createStylesElement } = require('./styles-element');
 const DEPRECATED_SYNTAX_SELECTORS = require('./deprecated-syntax-selectors');
 
 // Extended: A singleton instance of this class available via `atom.styles`,
@@ -254,7 +254,7 @@ module.exports = class StyleManager {
   }
 
   buildStylesElement() {
-    const stylesElement = new StylesElement();
+    const stylesElement = createStylesElement();
     stylesElement.initialize(this);
     return stylesElement;
   }


### PR DESCRIPTION
`document.registerElement` will be deprecated which will make moving to later electrons impossible. This PR updates `styles-element` to use [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements)

