### PR TITLE
Use customElement for the specs

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -18,15 +18,15 @@ const SAMPLE_TEXT = fs.readFileSync(
   'utf8'
 );
 
-document.registerElement('text-editor-component-test-element', {
-  prototype: Object.create(HTMLElement.prototype, {
-    attachedCallback: {
-      value: function() {
-        this.didAttach();
-      }
-    }
-  })
-});
+class DummyElement extends HTMLElement {
+  connectedCallback() {
+    this.didAttach();
+  }
+}
+
+window.customElements.define('text-editor-component-test-element', DummyElement)
+
+document.createElement('text-editor-component-test-element')
 
 const editors = [];
 let verticalScrollbarWidth, horizontalScrollbarHeight;


### PR DESCRIPTION
`document.registerElement `will be deprecated on chrome bundled with
electron 11. This makes it impossible to upgrade