### PR TITLE
Upgrade to electron 11.4.12 for security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "11.4.11",
+  "electronVersion": "11.4.12",
   "dependencies": {
     "@atom/fuzzy-native": "^1.2.1",
     "@atom/nsfw": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "11.4.7",
+  "electronVersion": "11.4.11",
   "dependencies": {
     "@atom/fuzzy-native": "^1.2.1",
     "@atom/nsfw": "^1.0.28",


### PR DESCRIPTION
Upgrade to electron 11.4.11 for some security fixes in the Electron 11 branch