### PR TITLE
[atom.sh] Remove REDIRECT_STDERR -h/-v flags

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -48,7 +48,6 @@ while getopts ":anwtfvh-:" opt; do
           WAIT=1
           ;;
         help|version)
-          REDIRECT_STDERR=1
           EXPECT_OUTPUT=1
           ;;
         foreground|benchmark|benchmark-test|test)
@@ -69,7 +68,6 @@ while getopts ":anwtfvh-:" opt; do
       WAIT=1
       ;;
     h|v)
-      REDIRECT_STDERR=1
       EXPECT_OUTPUT=1
       ;;
     f|t)


### PR DESCRIPTION
### Identify the Bug

On Mac, the `atom.sh` (or `/usr/local/bin/atom`) won't output the full Atom help text when providing the `--help` or `-h` flags. This is due to `STDERR` being redirected to `/dev/null` for those flags.

### Description of the Change

This solution simply removes the `REDIRECT_STDERR=1` from those flags.

### Alternate Designs

My first though was to separate the help flag from the version flag in the `case` block, and set `ATOM_HELP=1`
Then a little further down, simply run something like `${ATOM_APP}/Contents/MacOS/Atom -h`, if `ATOM_HELP` is 1.

With a little bit of testing, I realised that the help text is output to `STDERR`, and I found my proposed change to be a much simpler one.

### Possible Drawbacks

I am guessing that the `STDERR` was redirected for a reason for these flags. Which makes me think that they might output e.g. error messages, in some cases. But I have not been able to make Atom output anything other than the version/help text from the command with these flags.

### Verification Process

I created a separate file for `atom.sh` outside of the `Atom.app`, and changed the lines directly after
```shell
if [ $OS == 'Mac' ]; then
```
where it checks if the script is a link, and sets the `SCRIPT` variable, to look like this:
```shell
if [ $OS == 'Mac' ]; then
  SCRIPT="$(readlink "/usr/local/bin/atom")"
```

After changing this, I could test that my changes to `atom.sh` worked as expected.

### Release Notes

- Fixed the issue where the Atom CLI tool won't output full help text.

