### PR TITLE
document.registerElement polyfil

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2892,6 +2892,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
+    "document-register-element": {
+      "version": "1.14.10",
+      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.14.10.tgz",
+      "integrity": "sha512-w5UA37hEIrs+9pruo2yR5UD13c4UHDlkqqjt4qurnp7QsBI9b1IOi8WXUim+aCqKBsENX3Z/cso7XMOuwJH1Yw=="
+    },
     "dom-serializer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "deprecation-cop": "file:packages/deprecation-cop",
     "dev-live-reload": "file:packages/dev-live-reload",
     "devtron": "1.4.0",
+    "document-register-element": "^1.14.10",
     "electron-notarize": "1.0.0",
     "electron-osx-sign": "0.5.0",
     "encoding-selector": "https://www.atom.io/api/packages/encoding-selector/versions/0.23.9/tarball",

--- a/static/index.js
+++ b/static/index.js
@@ -145,6 +145,12 @@
       ? snapshotResult.customRequire('../src/crash-reporter-start.js')
       : require('../src/crash-reporter-start');
 
+    useSnapshot
+      ? snapshotResult.customRequire(
+          '../node_modules/document-register-element/build/document-register-element.node.js'
+        )
+      : require('document-register-element');
+
     const { userSettings, appVersion } = getWindowLoadSettings();
     const uploadToServer =
       userSettings &&


### PR DESCRIPTION
Atom is upgrading to use electron 11.4.7 however on that version
chromium has deprecated `document.registerElement`.

There are some community packages whose implementations depend on
`document.registerElement`. Therefore shipping without a polyfill will
break those packages.

As Atom maintainers we wouldn't want to introduce a change
that has the potential of breaking many packages.