### PR TITLE
Add prevent option to ::onWillDestroyPaneItem

### DIFF
--- a/spec/pane-container-spec.js
+++ b/spec/pane-container-spec.js
@@ -391,7 +391,7 @@ describe('PaneContainer', () => {
     });
   });
 
-  describe('::onWillDestroyPaneItem() and ::onDidDestroyPaneItem', () => {
+  describe('::onWillDestroyPaneItem() and ::onDidDestroyPaneItem()', () => {
     it('invokes the given callbacks when an item will be destroyed on any pane', async () => {
       const container = new PaneContainer(params);
       const pane1 = container.getRoot();
@@ -409,14 +409,37 @@ describe('PaneContainer', () => {
       await pane2.destroyItem(item3);
       await pane2.destroyItem(item2);
 
-      expect(events).toEqual([
-        ['will', { item: item1, pane: pane1, index: 0 }],
-        ['did', { item: item1, pane: pane1, index: 0 }],
-        ['will', { item: item3, pane: pane2, index: 1 }],
-        ['did', { item: item3, pane: pane2, index: 1 }],
-        ['will', { item: item2, pane: pane2, index: 0 }],
-        ['did', { item: item2, pane: pane2, index: 0 }]
+      expect(events.length).toBe(6);
+      expect(events[1]).toEqual([
+        'did',
+        { item: item1, pane: pane1, index: 0 }
       ]);
+      expect(events[3]).toEqual([
+        'did',
+        { item: item3, pane: pane2, index: 1 }
+      ]);
+      expect(events[5]).toEqual([
+        'did',
+        { item: item2, pane: pane2, index: 0 }
+      ]);
+
+      expect(events[0][0]).toEqual('will');
+      expect(events[0][1].item).toEqual(item1);
+      expect(events[0][1].pane).toEqual(pane1);
+      expect(events[0][1].index).toEqual(0);
+      expect(typeof events[0][1].prevent).toEqual('function');
+
+      expect(events[2][0]).toEqual('will');
+      expect(events[2][1].item).toEqual(item3);
+      expect(events[2][1].pane).toEqual(pane2);
+      expect(events[2][1].index).toEqual(1);
+      expect(typeof events[2][1].prevent).toEqual('function');
+
+      expect(events[4][0]).toEqual('will');
+      expect(events[4][1].item).toEqual(item2);
+      expect(events[4][1].pane).toEqual(pane2);
+      expect(events[4][1].index).toEqual(0);
+      expect(typeof events[4][1].prevent).toEqual('function');
     });
   });
 

--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -568,6 +568,32 @@ describe('Pane', () => {
       expect(pane.getActiveItem()).toBeUndefined();
     });
 
+    it('does nothing if prevented', () => {
+      const container = new PaneContainer({
+        config: atom.config,
+        deserializerManager: atom.deserializers,
+        applicationDelegate: atom.applicationDelegate
+      });
+
+      pane.setContainer(container);
+      container.onWillDestroyPaneItem(e => e.prevent());
+      pane.itemStack = [item2, item3, item1];
+
+      pane.activateItem(item1);
+      expect(pane.getActiveItem()).toBe(item1);
+      pane.destroyItem(item3);
+      expect(pane.itemStack).toEqual([item2, item3, item1]);
+      expect(pane.getActiveItem()).toBe(item1);
+
+      pane.destroyItem(item1);
+      expect(pane.itemStack).toEqual([item2, item3, item1]);
+      expect(pane.getActiveItem()).toBe(item1);
+
+      pane.destroyItem(item2);
+      expect(pane.itemStack).toEqual([item2, item3, item1]);
+      expect(pane.getActiveItem()).toBe(item1);
+    });
+
     it('invokes ::onWillDestroyItem() and PaneContainer::onWillDestroyPaneItem observers before destroying the item', async () => {
       jasmine.useRealClock();
       pane.container = new PaneContainer({ config: atom.config, confirm });
@@ -589,10 +615,16 @@ describe('Pane', () => {
 
       await pane.destroyItem(item2);
       expect(item2.isDestroyed()).toBe(true);
-      expect(events).toEqual([
-        ['will-destroy-item', { item: item2, index: 1 }],
-        ['will-destroy-pane-item', { item: item2, index: 1, pane }]
-      ]);
+
+      expect(events[0][0]).toEqual('will-destroy-item');
+      expect(events[0][1].item).toEqual(item2);
+      expect(events[0][1].index).toEqual(1);
+
+      expect(events[1][0]).toEqual('will-destroy-pane-item');
+      expect(events[1][1].item).toEqual(item2);
+      expect(events[1][1].index).toEqual(1);
+      expect(typeof events[1][1].prevent).toEqual('function');
+      expect(events[1][1].pane).toEqual(pane);
     });
 
     it('invokes ::onWillRemoveItem() observers', () => {

--- a/src/pane.js
+++ b/src/pane.js
@@ -814,6 +814,9 @@ module.exports = class Pane {
   // last item, the pane will be destroyed if the `core.destroyEmptyPanes` config
   // setting is `true`.
   //
+  // This action can be prevented by onWillDestroyPaneItem callbacks in which
+  // case nothing happens.
+  //
   // * `item` Item to destroy
   // * `force` (optional) {Boolean} Destroy the item without prompting to save
   //    it, even if the item's `isPermanentDockItem` method returns true.
@@ -844,7 +847,16 @@ module.exports = class Pane {
         'will-destroy-pane-item'
       ) > 0
     ) {
-      await this.container.willDestroyPaneItem({ item, index, pane: this });
+      let preventClosing = false;
+      await this.container.willDestroyPaneItem({
+        item,
+        index,
+        pane: this,
+        prevent: () => {
+          preventClosing = true;
+        }
+      });
+      if (preventClosing) return false;
     }
 
     if (


### PR DESCRIPTION
<!--
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.
-->

### Issue or RFC Endorsed by Atom's Maintainers

#13812

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

This PR implements the feature requested in issue #12376. It adds a method to the parameter of the `::onWillDestroyPaneItem` callback named `prevent` which allows packages to prevent a tab from closing by adding an event listener via `::onWillDestroyPaneItem`.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

An alternative for the requested feature overall isn't really present, as the previous implementation would close the tab no matter what or request the user to safe in case of unsaved changes. Both of these are unwanted behaviour as described in #12376.

As for alternative ways to implement the functionality, I considered `prevent` to be a (boolean) value instead of a function. However, this seemed not such a good choice mainly because I find it more intuitive to use as a function, but also because JavaScript can't enforce the value to be a boolean.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

When used incorrectly this functionality could make closing tabs impossible for users. However, simply disabling the package that uses this functionality incorrectly will solve the problem.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I tested the functionality by using it in the [pinned-tabs-for-atom](https://github.com/ericcornelissen/pinned-tabs-for-atom) package when I created #13812. I have not yet been able to retest it yet.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

Not applicable

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
