### PR TITLE
Remove `isValidDimensions`; add `dimensionsAreOnScreen`

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -801,15 +801,16 @@ class AtomEnvironment {
     return Promise.all(steps);
   }
 
-  // Returns true if the dimensions are useable, false if they should be ignored.
+  // Returns true if the dimensions are usable, false if they should be ignored.
   // Work around for https://github.com/atom/atom-shell/issues/473
-  isValidDimensions({ x, y, width, height } = {}) {
-    return width > 0 && height > 0 && x + width > 0 && y + height > 0;
+  // Calls isMinimized because of https://github.com/atom/atom/issues/15019
+  isValidDimensions() {
+    return !this.getCurrentWindow().isMinimized();
   }
 
   storeWindowDimensions() {
     this.windowDimensions = this.getWindowDimensions();
-    if (this.isValidDimensions(this.windowDimensions)) {
+    if (this.isValidDimensions()) {
       localStorage.setItem(
         'defaultWindowDimensions',
         JSON.stringify(this.windowDimensions)

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -801,21 +801,12 @@ class AtomEnvironment {
     return Promise.all(steps);
   }
 
-  // Returns true if the dimensions are usable, false if they should be ignored.
-  // Work around for https://github.com/atom/atom-shell/issues/473
-  // Calls isMinimized because of https://github.com/atom/atom/issues/15019
-  isValidDimensions() {
-    return !this.getCurrentWindow().isMinimized();
-  }
-
   storeWindowDimensions() {
     this.windowDimensions = this.getWindowDimensions();
-    if (this.isValidDimensions()) {
-      localStorage.setItem(
-        'defaultWindowDimensions',
-        JSON.stringify(this.windowDimensions)
-      );
-    }
+    localStorage.setItem(
+      'defaultWindowDimensions',
+      JSON.stringify(this.windowDimensions)
+    );
   }
 
   getDefaultWindowDimensions() {

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -804,17 +804,17 @@ class AtomEnvironment {
   // Checks if window dimensions are onscreen (on the workArea part of a display).
   // The dimensions currently have to be completely onscreen for this to return true.
   dimensionsAreOnScreen(dimensions) {
-    for (const display of screen.getAllDisplays()) {
+    for (const { workArea } of screen.getAllDisplays()) {
       if (
-        display.workArea.x <= dimensions.x &&
-        display.workArea.y <= dimensions.y &&
-        display.workArea.x + display.workArea.width >= dimensions.x + dimensions.width &&
-        display.workArea.y + display.workArea.height >= dimensions.y + dimensions.height
+        workArea.x <= dimensions.x &&
+        workArea.y <= dimensions.y &&
+        workArea.x + workArea.width >= dimensions.x + dimensions.width &&
+        workArea.y + workArea.height >= dimensions.y + dimensions.height
       ) {
-        return true
+        return true;
       }
     }
-    return false
+    return false;
   }
 
   storeWindowDimensions() {

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -801,13 +801,15 @@ class AtomEnvironment {
     return Promise.all(steps);
   }
 
+  // Checks if window dimensions are onscreen (on the workArea part of a display).
+  // The dimensions currently have to be completely onscreen for this to return true.
   dimensionsAreOnScreen(dimensions) {
     for (const display of screen.getAllDisplays()) {
       if (
-        display.workArea.x < dimensions.x &&
-        display.workArea.y < dimensions.y &&
-        display.workArea.x + display.workArea.width > dimensions.x + dimensions.width &&
-        display.workArea.y + display.workArea.height > dimensions.y + dimensions.height
+        display.workArea.x <= dimensions.x &&
+        display.workArea.y <= dimensions.y &&
+        display.workArea.x + display.workArea.width >= dimensions.x + dimensions.width &&
+        display.workArea.y + display.workArea.height >= dimensions.y + dimensions.height
       ) {
         return true
       }

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const path = require('path');
 const util = require('util');
-const { ipcRenderer } = require('electron');
+const { ipcRenderer, screen } = require('electron');
 
 const _ = require('underscore-plus');
 const { deprecate } = require('grim');
@@ -801,6 +801,20 @@ class AtomEnvironment {
     return Promise.all(steps);
   }
 
+  dimensionsAreOnScreen(dimensions) {
+    for (const display of screen.getAllDisplays()) {
+      if (
+        display.workArea.x < dimensions.x &&
+        display.workArea.y < dimensions.y &&
+        display.workArea.x + display.workArea.width > dimensions.x + dimensions.width &&
+        display.workArea.y + display.workArea.height > dimensions.y + dimensions.height
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
   storeWindowDimensions() {
     this.windowDimensions = this.getWindowDimensions();
     localStorage.setItem(
@@ -821,7 +835,7 @@ class AtomEnvironment {
       localStorage.removeItem('defaultWindowDimensions');
     }
 
-    if (dimensions && this.isValidDimensions(dimensions)) {
+    if (dimensions && this.dimensionsAreOnScreen(dimensions)) {
       return dimensions;
     } else {
       const {


### PR DESCRIPTION
### bug

Since a second monitor could have a negative displacement compared to the first monitor, the original logic leads to false negatives.

See #15019

<sup>Keyword for detection: Fixes #15019; Fixes #6939</sup>

__Edit: See [the comment directly below this one](https://github.com/atom/atom/pull/22973#issuecomment-924168285)__

### Explain change

Currently, `isValidDimensions` is used for both checking when validating in storeWindowDimensions and getDefaultWindowDimensions.

But sometimes it returns a false positive for storing window dimensions.
It's impossible to predict whether window dimensions would be invalid in the future, so the use in `storeWindowDimensions` is removed.

For `getDefaultWindowDimensions` it should check whether the window would be on a screen.
For example, if a window was opened on screen 2, then exited, then screen 2 was turned off; the window should reopen on screen 1.

### Possible Drawbacks

none?

I imported `electron.screen`, but maybe there's another way. This was the easiest.
It would probably be better to allow some of the screen to be offscreen.

### Verification Process

Wow, green!

- [ ] add tests (then make ready for review)

### Release notes

<s>Fix false negatives when checking if window dimensions can be stored.</s>
Remove check for whether window dimensions are valid since that was fixed in electron.
Prevent windows from opening offscreen.