### PR TITLE
bootstrap: Use legacy-compatible `catch` syntax (support older Node)

### DIFF
--- a/script/lib/verify-machine-requirements.js
+++ b/script/lib/verify-machine-requirements.js
@@ -94,7 +94,7 @@ function verifyPython() {
           env: process.env,
           stdio: ['ignore', 'pipe', 'ignore']
         });
-      } catch {}
+      } catch (e) {}
 
       if (stdout) {
         if (stdout.indexOf('+') !== -1)


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Fixes #22969

### Description of the Change

<!--


We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- Use `catch` syntax in `script/lib/verify-machine-requirements.js` that is backward-compatible with older Node (9 and older)
  - Node 10 introduced `catch {}` blocks without needing to bind the exception. Older Node requires the exception to be bound, like this: `catch (exceptionVarName) {}`.

Side note:
  - (You can't actually build Atom with any Node version less than 10.12 anymore, but the system requirements checker script really should support older versions of Node... If only so we can print more-useful errors about users' versions of Node being too old.)
  - We want the script to get far enough to print a nice error telling them their Node is too old, not throw an obscure syntax error about `try`/`catch` block syntax! (https://github.com/atom/atom/issues/22969).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Allows the rather outdated Node check to function as written.

The Node version check should be updated... Please consider merging https://github.com/atom/atom/pull/23001 along with this PR.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

- Ran`script/bootstrap` and `script/build` on Node 9 and older.

Result: Users with Node older than 10 who run `script/bootstrap` (or `script/build`) can now get through the earliest part, `script/lib/verify-machine-requirements.js`, without encountering syntax errors. That means the script can properly do its job of detecting build dependency versions and printing their version numbers... and/or printing warnings or errors if the versions are too old to build Atom.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
N/A