### PR TITLE
Remove duplicate `to`

### DIFF
--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -169,7 +169,7 @@ module.exports = class GrammarRegistry {
   }
 
   // Extended: Get the `languageId` that has been explicitly assigned to
-  // to the given buffer, if any.
+  // the given buffer, if any.
   //
   // Returns a {String} id of the language
   getAssignedLanguageId(buffer) {


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.

### Description of the Change

The word `to` is a duplicate here. (Typical duplicate word error)

The periods/full stops for return types in the documentation seems inconsistent, but I'm ignoring that for now

### Release Notes

N/A
