### PR TITLE
bootstrap: Update Node requirement to 10.12+ in system requirement checker

### DIFF
--- a/script/lib/verify-machine-requirements.js
+++ b/script/lib/verify-machine-requirements.js
@@ -14,16 +14,12 @@ module.exports = function(ci) {
 function verifyNode() {
   const fullVersion = process.versions.node;
   const majorVersion = fullVersion.split('.')[0];
-  if (majorVersion >= 6) {
+  const minorVersion = fullVersion.split('.')[1];
+  if (majorVersion >= 11 || (majorVersion === '10' && minorVersion >= 12)) {
     console.log(`Node:\tv${fullVersion}`);
-  } else if (majorVersion >= 4) {
-    console.log(`Node:\tv${fullVersion}`);
-    console.warn(
-      '\tWarning: Building on Node below version 6 is deprecated. Please use Node 6.x+ to build Atom.'
-    );
   } else {
     throw new Error(
-      `node v4+ is required to build Atom. node v${fullVersion} is installed.`
+      `node v10.12+ is required to build Atom. node v${fullVersion} is installed.`
     );
   }
 }


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Companion PR to #22979.

### Description of the Change

<!--


We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- Update the required Node to build Atom to 10.12+ in the system requirements checker script. Because...
  - Node 10.12+ has been the practical minimum requirement to build Atom as of https://github.com/atom/atom/pull/20879.
  - If #22979 is merged without this, users of Node < 10.12 won't be properly warned that their version of Node is too old to properly build Atom.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I suppose we could hard require Node 10.12+, but "deprecate" anything less than currently, officially upstream-supported Node versions? (12.x is the oldest Node still supported by the Node maintainers as of my writing this. See: https://nodejs.org/en/about/releases/).

(I considered not updating the required Node, but the build script errors out with older Node, so it's not a useful check if we don't update it to 10.12+. I _do_ think Node 10.12+ is the sensible minimum requirement now.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Atom might be somewhat functional without a `chromedriver` binary, or without a startup cache? In which case this PR makes it harder to "mostly" build Atom on certain legacy or exotic OSes that we already don't support.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I ran `script/build --ci` with Node 9, Node 10.11, and Node 10.12.

- Before this PR, Node versions 4 or newer were allowed... with only a "deprecation warning" for Node 4 or 5... and with Node 6 and above being allowed without even a warning.
- I confirmed that Node 10.11 or lower will not actually work to build Atom though, due to `extract-zip@2` using the `recursive` option with `fs.mkdir`, which is only supported in Node 10.12 or newer, and can silently fail on older Node, leading to "file exists" errors in those older versions of Node.
  - Confirmed that Node 10.12 is perfectly capable of running the build scripts and producing a working build of Atom.
  - Now when attempting to bootstrap Atom on Node older than 10.12, the system requirements checker script throws a useful error message about Node being too old.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
N/A