### PR TITLE
Remember last opened state 

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1474,9 +1474,14 @@ module.exports = class AtomApplication extends EventEmitter {
   async saveCurrentWindowOptions(allowEmpty = false) {
     if (this.quitting) return;
 
+    const windows = this.getAllWindows();
+    const hasASpecWindow = windows.some(window => window.isSpec);
+
+    if (windows.length === 1 && hasASpecWindow) return;
+
     const state = {
       version: APPLICATION_STATE_VERSION,
-      windows: this.getAllWindows()
+      windows: windows
         .filter(window => !window.isSpec)
         .map(window => ({ projectRoots: window.projectRoots }))
     };


### PR DESCRIPTION
### Identify the Bug
Atom does not remember last-opened state if a spec window is closed last
<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Fixes https://github.com/atom/atom/issues/15793