### PR TITLE
Only remove trailing colons if on windows

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -749,7 +749,7 @@ describe('AtomApplication', function() {
       assert.isFalse(w._locations[0].isFile);
     });
 
-    if (process.platform === 'win32') {
+    if (process.platform === "win32") {
       it('truncates trailing whitespace and colons', async function() {
         await scenario.open(parseCommandLine(['b/2.md::  ']));
         await scenario.assert('[_ 2.md]');
@@ -761,8 +761,8 @@ describe('AtomApplication', function() {
       });
     } else {
       it('truncates trailing whitespace', async function() {
-        await scenario.open(parseCommandLine(['b/2.md::  ']));
-        await scenario.assert('[_ 2.md::]');
+        await scenario.open(parseCommandLine(['b/2.md  ']));
+        await scenario.assert('[_ 2.md]');
 
         const w = scenario.getWindow(0);
         assert.lengthOf(w._locations, 1);

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -749,15 +749,27 @@ describe('AtomApplication', function() {
       assert.isFalse(w._locations[0].isFile);
     });
 
-    it('truncates trailing whitespace and colons', async function() {
-      await scenario.open(parseCommandLine(['b/2.md::  ']));
-      await scenario.assert('[_ 2.md]');
+    if (process.platform === 'win32') {
+      it('truncates trailing whitespace and colons', async function() {
+        await scenario.open(parseCommandLine(['b/2.md::  ']));
+        await scenario.assert('[_ 2.md]');
 
-      const w = scenario.getWindow(0);
-      assert.lengthOf(w._locations, 1);
-      assert.isNull(w._locations[0].initialLine);
-      assert.isNull(w._locations[0].initialColumn);
-    });
+        const w = scenario.getWindow(0);
+        assert.lengthOf(w._locations, 1);
+        assert.isNull(w._locations[0].initialLine);
+        assert.isNull(w._locations[0].initialColumn);
+      });
+    } else {
+      it('truncates trailing whitespace', async function() {
+        await scenario.open(parseCommandLine(['b/2.md::  ']));
+        await scenario.assert('[_ 2.md::]');
+
+        const w = scenario.getWindow(0);
+        assert.lengthOf(w._locations, 1);
+        assert.isNull(w._locations[0].initialLine);
+        assert.isNull(w._locations[0].initialColumn);
+      });
+    }
 
     it('disregards test and benchmark windows', async function() {
       await scenario.launch(parseCommandLine(['--test', 'b']));

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1888,7 +1888,12 @@ module.exports = class AtomApplication extends EventEmitter {
       return result;
     }
 
-    result.pathToOpen = result.pathToOpen.replace(/[:\s]+$/, '');
+    const isWindows = process.platform === "win32";
+    if (isWindows) {
+      result.pathToOpen = result.pathToOpen.replace(/[:\s]+$/, '');
+    } else {
+      result.pathToOpen = result.pathToOpen.replace(/\s+$/, '');
+    }
     const match = result.pathToOpen.match(LocationSuffixRegExp);
 
     if (match != null) {
@@ -1901,11 +1906,10 @@ module.exports = class AtomApplication extends EventEmitter {
       }
     }
 
-    const normalizedPath = path.normalize(
-      path.resolve(executedFrom, fs.normalize(result.pathToOpen))
-    );
     if (!url.parse(pathToOpen).protocol) {
-      result.pathToOpen = normalizedPath;
+      result.pathToOpen = path.normalize(
+        path.resolve(executedFrom, fs.normalize(result.pathToOpen))
+      );
     }
 
     await new Promise((resolve, reject) => {


### PR DESCRIPTION
__Edit: I just realized this is pretty much a duplicate of #21124__

⚛👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.

### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

Fixes #20077
<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

Previously, trailing colons and whitespace was removed despite the operating system,

but now if it's not windows, only remove whitespace.


`normalizePath` is only used once. So by moving it into the if statement, theoretically maybe a few ms would be saved. But this isn't tested or really important.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

I thought about retrying the path without colons if the filepath ending in a colon failed, but that's too complicated.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

This reintroduces https://github.com/atom/atom/issues/6654, but I think it makes more sense to fail when the file with a colon doesn't exist and succeed when it does, rather than just eliminating colons.

Since this is a good first issue, it would be better if someone else tried this out.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- [ ] Tests (not done)
<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

N/A?
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
