### PR TITLE
Replace remote module with invoke calls.

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -133,6 +133,13 @@ const decryptOptions = (optionsMessage, secret) => {
   return JSON.parse(message);
 };
 
+ipcMain.handle('isDefaultProtocolClient', (_, { protocol, path, args }) => {
+  return app.isDefaultProtocolClient(protocol, path, args);
+});
+
+ipcMain.handle('setAsDefaultProtocolClient', (_, { protocol, path, args }) => {
+  return app.setAsDefaultProtocolClient(protocol, path, args);
+});
 // The application's singleton class.
 //
 // It's the entry point into the Atom application and maintains the global state


### PR DESCRIPTION
The remote module has been deprecated and is set to be removed on electron version 11.
We have two options to replace the remote module

1. use @electron/remote module
2. Send messages using send/invoke.

I am using invoke since it is the
[recommended](https://www.npmjs.com/package/@electron/remote) option to use.


