### PR TITLE
Change from `crashed` to `render-process-gone`

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -236,34 +236,37 @@ module.exports = class AtomWindow extends EventEmitter {
       if (result.response === 0) this.browserWindow.destroy();
     });
 
-    this.browserWindow.webContents.on('render-process-gone', async (event, { reason }) => {
-      if (reason === "crashed") {
-        if (this.headless) {
-          console.log('Renderer process crashed, exiting');
-          this.atomApplication.exit(100);
-          return;
-        }
+    this.browserWindow.webContents.on(
+      'render-process-gone',
+      async (event, { reason }) => {
+        if (reason === "crashed") {
+          if (this.headless) {
+            console.log('Renderer process crashed, exiting');
+            this.atomApplication.exit(100);
+            return;
+          }
 
-        await this.fileRecoveryService.didCrashWindow(this);
+          await this.fileRecoveryService.didCrashWindow(this);
 
-        const result = await dialog.showMessageBox(this.browserWindow, {
-          type: 'warning',
-          buttons: ['Close Window', 'Reload', 'Keep It Open'],
-          cancelId: 2, // Canceling should be the least destructive action
-          message: 'The editor has crashed',
-          detail: 'Please report this issue to https://github.com/atom/atom'
-        });
+          const result = await dialog.showMessageBox(this.browserWindow, {
+            type: 'warning',
+            buttons: ['Close Window', 'Reload', 'Keep It Open'],
+            cancelId: 2, // Canceling should be the least destructive action
+            message: 'The editor has crashed',
+            detail: 'Please report this issue to https://github.com/atom/atom'
+          });
 
-        switch (result.response) {
-          case 0:
-            this.browserWindow.destroy();
-            break;
-          case 1:
-            this.browserWindow.reload();
-            break;
+          switch (result.response) {
+            case 0:
+              this.browserWindow.destroy();
+              break;
+            case 1:
+              this.browserWindow.reload();
+              break;
+          }
         }
       }
-    });
+    );
 
     this.browserWindow.webContents.on('will-navigate', (event, url) => {
       if (url !== this.browserWindow.webContents.getURL())

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -239,7 +239,7 @@ module.exports = class AtomWindow extends EventEmitter {
     this.browserWindow.webContents.on(
       'render-process-gone',
       async (event, { reason }) => {
-        if (reason === "crashed") {
+        if (reason === 'crashed') {
           if (this.headless) {
             console.log('Renderer process crashed, exiting');
             this.atomApplication.exit(100);

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -236,30 +236,32 @@ module.exports = class AtomWindow extends EventEmitter {
       if (result.response === 0) this.browserWindow.destroy();
     });
 
-    this.browserWindow.webContents.on('crashed', async () => {
-      if (this.headless) {
-        console.log('Renderer process crashed, exiting');
-        this.atomApplication.exit(100);
-        return;
-      }
+    this.browserWindow.webContents.on('render-process-gone', async (event, { reason }) => {
+      if (reason === "crashed") {
+        if (this.headless) {
+          console.log('Renderer process crashed, exiting');
+          this.atomApplication.exit(100);
+          return;
+        }
 
-      await this.fileRecoveryService.didCrashWindow(this);
+        await this.fileRecoveryService.didCrashWindow(this);
 
-      const result = await dialog.showMessageBox(this.browserWindow, {
-        type: 'warning',
-        buttons: ['Close Window', 'Reload', 'Keep It Open'],
-        cancelId: 2, // Canceling should be the least destructive action
-        message: 'The editor has crashed',
-        detail: 'Please report this issue to https://github.com/atom/atom'
-      });
+        const result = await dialog.showMessageBox(this.browserWindow, {
+          type: 'warning',
+          buttons: ['Close Window', 'Reload', 'Keep It Open'],
+          cancelId: 2, // Canceling should be the least destructive action
+          message: 'The editor has crashed',
+          detail: 'Please report this issue to https://github.com/atom/atom'
+        });
 
-      switch (result.response) {
-        case 0:
-          this.browserWindow.destroy();
-          break;
-        case 1:
-          this.browserWindow.reload();
-          break;
+        switch (result.response) {
+          case 0:
+            this.browserWindow.destroy();
+            break;
+          case 1:
+            this.browserWindow.reload();
+            break;
+        }
       }
     });
 


### PR DESCRIPTION
The `crashed` event handler is deprecated, so this pr switches to `render-process-gone`
https://github.com/electron/electron/blob/9-x-y/docs/api/web-contents.md#event-crashed-deprecated

Note: The previous code shows the error dialog on both the "killed" and "crashed" events. But now it's only when "crashed"
Note 2: Diff without whitespace https://github.com/atom/atom/pull/23132/files?diff=split&w=1
