### PR TITLE
Default themes maintenance

### DIFF
--- a/packages/atom-dark-syntax/styles/syntax/base.less
+++ b/packages/atom-dark-syntax/styles/syntax/base.less
@@ -232,21 +232,10 @@
 .syntax--comment {
   color: #8A8A8A;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: lighten(#8A8A8A, 6);
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: lighten(#8A8A8A, 9);
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: #8A8A8A;
-    font-weight: normal;
   }
 }
 

--- a/packages/atom-dark-syntax/styles/syntax/base.less
+++ b/packages/atom-dark-syntax/styles/syntax/base.less
@@ -152,7 +152,7 @@
       color: #96CBFE;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: #C5C8C6;
     }

--- a/packages/atom-dark-syntax/styles/syntax/css.less
+++ b/packages/atom-dark-syntax/styles/syntax/css.less
@@ -93,9 +93,7 @@
     }
   }
 
-  // . : :: # [] ()
   .syntax--punctuation {
-    color: #C5C8C6;
 
     // *
     &.syntax--wildcard {

--- a/packages/atom-dark-syntax/styles/syntax/css.less
+++ b/packages/atom-dark-syntax/styles/syntax/css.less
@@ -102,3 +102,20 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: #FFD2A7;
+
+      // url rgb
+      &.syntax--support {
+        color: #DAD085;
+      }
+    }
+  }
+}

--- a/packages/atom-dark-syntax/styles/syntax/css.less
+++ b/packages/atom-dark-syntax/styles/syntax/css.less
@@ -47,8 +47,8 @@
       color: #C6C5FE;
     }
 
-    // @keyframes keyframe
-    &.syntax--keyframe {
+    // @keyframes keyframes
+    &.syntax--keyframes {
       color: #C6C5FE;
     }
   }

--- a/packages/atom-light-syntax/styles/syntax/base.less
+++ b/packages/atom-light-syntax/styles/syntax/base.less
@@ -136,8 +136,8 @@
       color: #008080;
     }
 
-    // ( ) [^ ] (?= ) | r" /
-    &.syntax--punctuation {
+    // ( ) [^ ] (?= ) |
+    &.syntax--punctuation.syntax--part {
       color: #222;
     }
   }

--- a/packages/atom-light-syntax/styles/syntax/base.less
+++ b/packages/atom-light-syntax/styles/syntax/base.less
@@ -197,21 +197,10 @@
   color: #999988;
   font-style: italic;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: lighten(#999988, 6);
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: lighten(#999988, 9);
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: #999988;
-    font-weight: normal;
   }
 }
 

--- a/packages/atom-light-syntax/styles/syntax/base.less
+++ b/packages/atom-light-syntax/styles/syntax/base.less
@@ -131,7 +131,7 @@
       color: #222;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: #008080;
     }

--- a/packages/atom-light-syntax/styles/syntax/css.less
+++ b/packages/atom-light-syntax/styles/syntax/css.less
@@ -109,3 +109,20 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: #900;
+
+      // url rgb
+      &.syntax--support {
+        color: #458;
+      }
+    }
+  }
+}

--- a/packages/atom-light-syntax/styles/syntax/css.less
+++ b/packages/atom-light-syntax/styles/syntax/css.less
@@ -46,8 +46,8 @@
       color: #008080;
     }
 
-    // @keyframes keyframe
-    &.syntax--keyframe {
+    // @keyframes keyframes
+    &.syntax--keyframes {
       color: #606aa1;
     }
   }

--- a/packages/atom-light-syntax/styles/syntax/css.less
+++ b/packages/atom-light-syntax/styles/syntax/css.less
@@ -88,21 +88,24 @@
     }
   }
 
-  // . : :: #
-  .syntax--punctuation.syntax--selector {
-    color: #458;
-    font-weight: bold;
+  .syntax--punctuation {
 
-    // *
-    &.syntax--wildcard {
-      color: #008080;
-      font-weight: normal;
-    }
+    // . : :: #
+    &.syntax--selector {
+      color: #458;
+      font-weight: bold;
 
-    // []
-    &.syntax--attribute {
-      color: #555;
-      font-weight: normal;
+      // *
+      &.syntax--wildcard {
+        color: #008080;
+        font-weight: normal;
+      }
+
+      // []
+      &.syntax--attribute {
+        color: #555;
+        font-weight: normal;
+      }
     }
   }
 }

--- a/packages/base16-tomorrow-dark-theme/styles/syntax/base.less
+++ b/packages/base16-tomorrow-dark-theme/styles/syntax/base.less
@@ -264,21 +264,10 @@
 .syntax--comment {
   color: @gray;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: lighten(@gray, 3);
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: lighten(@gray, 7);
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: @gray;
-    font-weight: normal;
   }
 }
 

--- a/packages/base16-tomorrow-dark-theme/styles/syntax/base.less
+++ b/packages/base16-tomorrow-dark-theme/styles/syntax/base.less
@@ -137,7 +137,7 @@
       color: @purple;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: @blue;
     }

--- a/packages/base16-tomorrow-dark-theme/styles/syntax/css.less
+++ b/packages/base16-tomorrow-dark-theme/styles/syntax/css.less
@@ -37,8 +37,8 @@
       color: @red;
     }
 
-    // @keyframes keyframe
-    &.syntax--keyframe {
+    // @keyframes keyframes
+    &.syntax--keyframes {
       color: @red;
     }
   }

--- a/packages/base16-tomorrow-dark-theme/styles/syntax/css.less
+++ b/packages/base16-tomorrow-dark-theme/styles/syntax/css.less
@@ -111,3 +111,20 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: @blue;
+
+      // url rgb
+      &.syntax--support {
+        color: @cyan;
+      }
+    }
+  }
+}

--- a/packages/base16-tomorrow-light-theme/styles/syntax/base.less
+++ b/packages/base16-tomorrow-light-theme/styles/syntax/base.less
@@ -264,21 +264,10 @@
 .syntax--comment {
   color: @gray;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: lighten(@gray, 3);
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: lighten(@gray, 7);
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: @gray;
-    font-weight: normal;
   }
 }
 

--- a/packages/base16-tomorrow-light-theme/styles/syntax/base.less
+++ b/packages/base16-tomorrow-light-theme/styles/syntax/base.less
@@ -137,7 +137,7 @@
       color: @purple;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: @blue;
     }

--- a/packages/base16-tomorrow-light-theme/styles/syntax/css.less
+++ b/packages/base16-tomorrow-light-theme/styles/syntax/css.less
@@ -37,8 +37,8 @@
       color: @red;
     }
 
-    // @keyframes keyframe
-    &.syntax--keyframe {
+    // @keyframes keyframes
+    &.syntax--keyframes {
       color: @red;
     }
   }

--- a/packages/base16-tomorrow-light-theme/styles/syntax/css.less
+++ b/packages/base16-tomorrow-light-theme/styles/syntax/css.less
@@ -111,3 +111,20 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: @blue;
+
+      // url rgb
+      &.syntax--support {
+        color: @cyan;
+      }
+    }
+  }
+}

--- a/packages/one-dark-syntax/styles/syntax/base.less
+++ b/packages/one-dark-syntax/styles/syntax/base.less
@@ -84,18 +84,18 @@
   }
 }
 
-// () [] {} => @
+// () [] {} :
 .syntax--punctuation {
   color: @mono-1;
 
+  // . -> ::
   &.syntax--accessor {
-    color: @mono-1;
+    color: @hue-3;
+  }
 
-    // . -> ::
-    &.syntax--member,
-    &.syntax--scope {
-      color: @hue-3;
-    }
+  // * ... =>
+  &.syntax--operation {
+    color: @hue-3;
   }
 
   // { } ~~~

--- a/packages/one-dark-syntax/styles/syntax/base.less
+++ b/packages/one-dark-syntax/styles/syntax/base.less
@@ -132,7 +132,7 @@
       color: @hue-3;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: @hue-2;
     }

--- a/packages/one-dark-syntax/styles/syntax/base.less
+++ b/packages/one-dark-syntax/styles/syntax/base.less
@@ -277,21 +277,10 @@
   color: @mono-3;
   font-style: italic;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: lighten(@mono-3, 6);
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: lighten(@mono-3, 9);
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: @mono-3;
-    font-weight: normal;
   }
 }
 

--- a/packages/one-dark-syntax/styles/syntax/base.less
+++ b/packages/one-dark-syntax/styles/syntax/base.less
@@ -138,7 +138,7 @@
     }
 
     // ( ) [^ ] (?= ) |
-    &.syntax--punctuation {
+    &.syntax--punctuation.syntax--part {
       color: @hue-3;
     }
   }

--- a/packages/one-dark-syntax/styles/syntax/css.less
+++ b/packages/one-dark-syntax/styles/syntax/css.less
@@ -101,3 +101,20 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: @hue-2;
+
+      // url rgb
+      &.syntax--support {
+        color: @hue-1;
+      }
+    }
+  }
+}

--- a/packages/one-light-syntax/styles/syntax/base.less
+++ b/packages/one-light-syntax/styles/syntax/base.less
@@ -97,11 +97,6 @@
 // () [] {} => @
 .syntax--punctuation {
   color: @mono-1;
-
-  // . -> :: []
-  &.syntax--accessor {
-    color: @mono-1;
-  }
 }
 
 // "string"

--- a/packages/one-light-syntax/styles/syntax/base.less
+++ b/packages/one-light-syntax/styles/syntax/base.less
@@ -132,7 +132,7 @@
       color: @hue-3;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: @hue-2;
     }

--- a/packages/one-light-syntax/styles/syntax/base.less
+++ b/packages/one-light-syntax/styles/syntax/base.less
@@ -277,21 +277,10 @@
   color: @mono-3;
   font-style: italic;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: lighten(@mono-3, 6);
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: lighten(@mono-3, 9);
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: @mono-3;
-    font-weight: normal;
   }
 }
 

--- a/packages/one-light-syntax/styles/syntax/base.less
+++ b/packages/one-light-syntax/styles/syntax/base.less
@@ -138,7 +138,7 @@
     }
 
     // ( ) [^ ] (?= ) |
-    &.syntax--punctuation {
+    &.syntax--punctuation.syntax--part {
       color: @hue-3;
     }
   }

--- a/packages/one-light-syntax/styles/syntax/css.less
+++ b/packages/one-light-syntax/styles/syntax/css.less
@@ -101,3 +101,20 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: @hue-2;
+
+      // url rgb
+      &.syntax--support {
+        color: @hue-1;
+      }
+    }
+  }
+}

--- a/packages/solarized-dark-syntax/styles/syntax/base.less
+++ b/packages/solarized-dark-syntax/styles/syntax/base.less
@@ -256,21 +256,10 @@
   color: @syntax-comment-color;
   font-style: italic;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: @syntax-subtle-color;
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: @syntax-subtle-color;
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: @syntax-comment-color;
-    font-weight: normal;
   }
 }
 

--- a/packages/solarized-dark-syntax/styles/syntax/base.less
+++ b/packages/solarized-dark-syntax/styles/syntax/base.less
@@ -112,7 +112,7 @@
       color: @violet;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: @violet;
     }

--- a/packages/solarized-dark-syntax/styles/syntax/css.less
+++ b/packages/solarized-dark-syntax/styles/syntax/css.less
@@ -126,3 +126,15 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: @blue;
+    }
+  }
+}

--- a/packages/solarized-dark-syntax/styles/syntax/css.less
+++ b/packages/solarized-dark-syntax/styles/syntax/css.less
@@ -63,8 +63,8 @@
       color: @syntax-text-color;
     }
 
-    // @keyframes keyframe
-    &.syntax--keyframe {
+    // @keyframes keyframes
+    &.syntax--keyframes {
       color: @syntax-text-color;
     }
   }

--- a/packages/solarized-light-syntax/styles/syntax/base.less
+++ b/packages/solarized-light-syntax/styles/syntax/base.less
@@ -251,21 +251,10 @@
   color: @syntax-comment-color;
   font-style: italic;
 
-  // @param TODO NOTE
-  &.syntax--caption {
+  // @param TODO NOTE type { }
+  &.syntax--part {
     color: @syntax-subtle-color;
     font-weight: bold;
-  }
-
-  // variable function type
-  &.syntax--term {
-    color: @syntax-subtle-color;
-  }
-
-  // { } / .
-  &.syntax--punctuation {
-    color: @syntax-comment-color;
-    font-weight: normal;
   }
 }
 

--- a/packages/solarized-light-syntax/styles/syntax/base.less
+++ b/packages/solarized-light-syntax/styles/syntax/base.less
@@ -107,7 +107,7 @@
       color: @orange;
     }
 
-    // <variable> \1
+    // <variable>
     &.syntax--variable {
       color: @orange;
     }

--- a/packages/solarized-light-syntax/styles/syntax/css.less
+++ b/packages/solarized-light-syntax/styles/syntax/css.less
@@ -126,3 +126,15 @@
     }
   }
 }
+
+.syntax--source.syntax--css.syntax--scss,
+.syntax--source.syntax--css.syntax--less {
+
+  .syntax--entity {
+
+    // function()
+    &.syntax--function {
+      color: @blue;
+    }
+  }
+}

--- a/packages/solarized-light-syntax/styles/syntax/css.less
+++ b/packages/solarized-light-syntax/styles/syntax/css.less
@@ -63,8 +63,8 @@
       color: @syntax-text-color;
     }
 
-    // @keyframes keyframe
-    &.syntax--keyframe {
+    // @keyframes keyframes
+    &.syntax--keyframes {
       color: @syntax-text-color;
     }
   }


### PR DESCRIPTION
### Description

- Bug fixes:
    - Fixes comment punctuation in CSS
    - Adds a rule to highlight functions in Sass and Less differently than vanilla CSS

- Highlighting legibility improvements:
    - Simplifies JSDoc highlighting
    - Highlights regex quotes like string quotes
    - Highlights variadic and lambda punctuation to make them stand out like operators

### Related Issues

- https://github.com/atom/language-sass/issues/285

### Related Pull Request

https://github.com/atom/atom/pull/20524