### PR TITLE
Revert "Only allow drag-and-drop to succeed on panes in the center workspace"

### DIFF
--- a/spec/pane-element-spec.js
+++ b/spec/pane-element-spec.js
@@ -1,11 +1,19 @@
+const PaneContainer = require('../src/pane-container');
+
 describe('PaneElement', function() {
   let [paneElement, container, containerElement, pane] = [];
 
   beforeEach(function() {
     spyOn(atom.applicationDelegate, 'open');
 
-    container = atom.workspace.getActivePaneContainer();
-    containerElement = container.paneContainer.getElement();
+    container = new PaneContainer({
+      location: 'center',
+      config: atom.config,
+      confirm: atom.confirm.bind(atom),
+      viewRegistry: atom.views,
+      applicationDelegate: atom.applicationDelegate
+    });
+    containerElement = container.getElement();
     pane = container.getActivePane();
     paneElement = pane.getElement();
   });
@@ -269,9 +277,9 @@ describe('PaneElement', function() {
     }));
 
   describe('drag and drop', function() {
-    const buildDragEvent = function(type, items) {
+    const buildDragEvent = function(type, files) {
       const dataTransfer = {
-        items,
+        files,
         data: {},
         setData(key, value) {
           this.data[key] = value;
@@ -286,46 +294,26 @@ describe('PaneElement', function() {
       return event;
     };
 
-    describe('when the pane is in the center workspace', () => {
-      describe('when a file is dragged to the pane', () =>
-        it('opens it', function() {
-          const event = buildDragEvent('drop', [
-            { kind: 'file', getAsFile: () => ({ path: '/fake1' }) },
-            { kind: 'file', getAsFile: () => ({ path: '/fake2' }) }
-          ]);
-          paneElement.dispatchEvent(event);
-          expect(atom.applicationDelegate.open.callCount).toBe(1);
-          expect(atom.applicationDelegate.open.argsForCall[0][0]).toEqual({
-            pathsToOpen: ['/fake1', '/fake2'],
-            here: true
-          });
-        }));
-
-      describe('when a non-file is dragged to the pane', () =>
-        it('does nothing', function() {
-          const event = buildDragEvent('drop', []);
-          paneElement.dispatchEvent(event);
-          expect(atom.applicationDelegate.open).not.toHaveBeenCalled();
-        }));
-    });
-
-    describe('when the pane is not in the center workspace', () => {
-      beforeEach(() => {
-        pane = atom.workspace.getLeftDock().getActivePane();
-        paneElement = pane.getElement();
-      });
-
-      describe('when a drag event occurs', () => {
-        it('does nothing', () => {
-          const event = buildDragEvent('drop', [
-            { kind: 'file', getAsFile: () => ({ path: '/fake1' }) },
-            { kind: 'file', getAsFile: () => ({ path: '/fake2' }) }
-          ]);
-          paneElement.dispatchEvent(event);
-          expect(atom.applicationDelegate.open).not.toHaveBeenCalled();
+    describe('when a file is dragged to the pane', () =>
+      it('opens it', function() {
+        const event = buildDragEvent('drop', [
+          { path: '/fake1' },
+          { path: '/fake2' }
+        ]);
+        paneElement.dispatchEvent(event);
+        expect(atom.applicationDelegate.open.callCount).toBe(1);
+        expect(atom.applicationDelegate.open.argsForCall[0][0]).toEqual({
+          pathsToOpen: ['/fake1', '/fake2'],
+          here: true
         });
-      });
-    });
+      }));
+
+    describe('when a non-file is dragged to the pane', () =>
+      it('does nothing', function() {
+        const event = buildDragEvent('drop', []);
+        paneElement.dispatchEvent(event);
+        expect(atom.applicationDelegate.open).not.toHaveBeenCalled();
+      }));
   });
 
   describe('resize', () =>

--- a/src/pane-element.js
+++ b/src/pane-element.js
@@ -54,39 +54,15 @@ class PaneElement extends HTMLElement {
       }
     };
     const handleDragOver = event => {
-      const items = Array.from(event.dataTransfer.items).filter(
-        item => item.kind === 'file'
-      );
-      // TextEditors are only allowed in the center workspace, so make sure this pane is in the center
-      if (
-        items.length > 0 &&
-        atom.workspace
-          .getCenter()
-          .getPanes()
-          .includes(this.getModel())
-      ) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
+      event.preventDefault();
+      event.stopPropagation();
     };
     const handleDrop = event => {
-      const items = Array.from(event.dataTransfer.items).filter(
-        item => item.kind === 'file'
-      );
-      // TextEditors are only allowed in the center workspace, so make sure this pane is in the center
-      if (
-        items.length > 0 &&
-        atom.workspace
-          .getCenter()
-          .getPanes()
-          .includes(this.getModel())
-      ) {
-        event.preventDefault();
-        event.stopPropagation();
-        this.getModel().activate();
-
-        const files = items.map(item => item.getAsFile());
-        const pathsToOpen = files.map(file => file.path);
+      event.preventDefault();
+      event.stopPropagation();
+      this.getModel().activate();
+      const pathsToOpen = [...event.dataTransfer.files].map(file => file.path);
+      if (pathsToOpen.length > 0) {
         this.applicationDelegate.open({ pathsToOpen, here: true });
       }
     };

--- a/src/window-event-handler.js
+++ b/src/window-event-handler.js
@@ -78,6 +78,12 @@ module.exports = class WindowEventHandler {
       'keydown',
       this.handleDocumentKeyEvent
     );
+    this.addEventListener(this.document, 'drop', this.handleDocumentDrop);
+    this.addEventListener(
+      this.document,
+      'dragover',
+      this.handleDocumentDragover
+    );
     this.addEventListener(
       this.document,
       'contextmenu',
@@ -146,6 +152,17 @@ module.exports = class WindowEventHandler {
   handleDocumentKeyEvent(event) {
     this.atomEnvironment.keymaps.handleKeyboardEvent(event);
     event.stopImmediatePropagation();
+  }
+
+  handleDrop(event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  handleDragover(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'none';
   }
 
   eachTabIndexedElement(callback) {


### PR DESCRIPTION
Reverts atom/atom#19251

This is being reverted as a result of https://github.com/atom/atom/issues/23099