### PR TITLE
Remove `if (reason === crashed)`

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -236,37 +236,32 @@ module.exports = class AtomWindow extends EventEmitter {
       if (result.response === 0) this.browserWindow.destroy();
     });
 
-    this.browserWindow.webContents.on(
-      'render-process-gone',
-      async (event, { reason }) => {
-        if (reason === 'crashed') {
-          if (this.headless) {
-            console.log('Renderer process crashed, exiting');
-            this.atomApplication.exit(100);
-            return;
-          }
-
-          await this.fileRecoveryService.didCrashWindow(this);
-
-          const result = await dialog.showMessageBox(this.browserWindow, {
-            type: 'warning',
-            buttons: ['Close Window', 'Reload', 'Keep It Open'],
-            cancelId: 2, // Canceling should be the least destructive action
-            message: 'The editor has crashed',
-            detail: 'Please report this issue to https://github.com/atom/atom'
-          });
-
-          switch (result.response) {
-            case 0:
-              this.browserWindow.destroy();
-              break;
-            case 1:
-              this.browserWindow.reload();
-              break;
-          }
-        }
+    this.browserWindow.webContents.on('render-process-gone', async () => {
+      if (this.headless) {
+        console.log('Renderer process crashed, exiting');
+        this.atomApplication.exit(100);
+        return;
       }
-    );
+
+      await this.fileRecoveryService.didCrashWindow(this);
+
+      const result = await dialog.showMessageBox(this.browserWindow, {
+        type: 'warning',
+        buttons: ['Close Window', 'Reload', 'Keep It Open'],
+        cancelId: 2, // Canceling should be the least destructive action
+        message: 'The editor has crashed',
+        detail: 'Please report this issue to https://github.com/atom/atom'
+      });
+
+      switch (result.response) {
+        case 0:
+          this.browserWindow.destroy();
+          break;
+        case 1:
+          this.browserWindow.reload();
+          break;
+      }
+    });
 
     this.browserWindow.webContents.on('will-navigate', (event, url) => {
       if (url !== this.browserWindow.webContents.getURL())


### PR DESCRIPTION
Although `crashed` has recently been updated to `render-process-gone`, the new params don't actually have to be used. In fact maybe allowing some of the other crash-ishes could result in weird invalid state and things happening. So basically I agree with https://github.com/atom/atom/pull/23132#issuecomment-951434891

Maybe there should be a different message for the `killed` reason though