### PR TITLE
Improve Welcome Guide Ordering

### DIFF
--- a/packages/welcome/lib/guide-view.js
+++ b/packages/welcome/lib/guide-view.js
@@ -107,36 +107,6 @@ export default class GuideView {
 
             <details
               className="welcome-card"
-              {...this.getSectionProps('teletype')}
-            >
-              <summary className="welcome-summary icon icon-radio-tower">
-                Collaborate in real time with{' '}
-                <span class="welcome-highlight">Teletype</span>
-              </summary>
-              <div className="welcome-detail">
-                <p>
-                  <img
-                    className="welcome-img"
-                    src="atom://welcome/assets/code.svg"
-                  />
-                </p>
-                <p>
-                  Share your workspace with team members and collaborate on code
-                  in real time.
-                </p>
-                <p>
-                  <button
-                    onclick={this.didClickTeletypeButton}
-                    className="btn btn-primary inline-block"
-                  >
-                    Install Teletype for Atom
-                  </button>
-                </p>
-              </div>
-            </details>
-
-            <details
-              className="welcome-card"
               {...this.getSectionProps('packages')}
             >
               <summary className="welcome-summary icon icon-package">
@@ -166,6 +136,36 @@ export default class GuideView {
                 <p className="welcome-note">
                   <strong>Next time:</strong> You can install new packages from
                   the settings.
+                </p>
+              </div>
+            </details>
+
+            <details
+              className="welcome-card"
+              {...this.getSectionProps('teletype')}
+            >
+              <summary className="welcome-summary icon icon-radio-tower">
+                Collaborate in real time with{' '}
+                <span class="welcome-highlight">Teletype</span>
+              </summary>
+              <div className="welcome-detail">
+                <p>
+                  <img
+                    className="welcome-img"
+                    src="atom://welcome/assets/code.svg"
+                  />
+                </p>
+                <p>
+                  Share your workspace with team members and collaborate on code
+                  in real time.
+                </p>
+                <p>
+                  <button
+                    onclick={this.didClickTeletypeButton}
+                    className="btn btn-primary inline-block"
+                  >
+                    Install Teletype for Atom
+                  </button>
                 </p>
               </div>
             </details>


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

On the Welcome Guide, the user is introduced to the package manager with Teletype before they reach the "Install a Package" card. This makes the Installer card is less useful since the user has already seen the packages.

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

Move "Install a Package"  before "Collaborate in real time with Teletype" since installing Teletype brings the user to the package installer. It'd make more sense to introduce them to packages and then recommend Teletype.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

I considered the current order but decided it doesn't work as well as this. Additionally, Theming and Styling cards might be better before the Installing cards. The reason is because the following cards include Hacking the Init Script and adding Snippets. I didn't change this, though, because it's a bit too large of a change without feedback in my opinion.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

The possible drawback is not knowing what to install through the installer... But since the following card recommends Teletype, it should be fine.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I reopened the app and the cards were in their correct order.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

Reordered welcome guide to put package installation before Teletype promo.

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->