### PR TITLE
⬆️ marked to 4.0.10 in packages/deprecation-cop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2823,7 +2823,7 @@
         "etch": "0.9.0",
         "fs-plus": "^3.0.0",
         "grim": "^2.0.1",
-        "marked": "^0.3.6",
+        "marked": "^4.0.10",
         "underscore-plus": "^1.7.0"
       },
       "dependencies": {
@@ -2841,9 +2841,9 @@
           }
         },
         "marked": {
-          "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-          "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+          "version": "4.0.10",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+          "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
         }
       }
     },

--- a/packages/deprecation-cop/lib/deprecation-cop-view.js
+++ b/packages/deprecation-cop/lib/deprecation-cop-view.js
@@ -6,7 +6,7 @@ import { CompositeDisposable } from 'atom';
 import etch from 'etch';
 import fs from 'fs-plus';
 import Grim from 'grim';
-import marked from 'marked';
+import { marked } from 'marked';
 import path from 'path';
 import { shell } from 'electron';
 

--- a/packages/deprecation-cop/package.json
+++ b/packages/deprecation-cop/package.json
@@ -12,7 +12,7 @@
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
-    "marked": "^0.3.6",
+    "marked": "^4.0.10",
     "underscore-plus": "^1.7.0"
   },
   "consumedServices": {


### PR DESCRIPTION
Updates `marked`

Equivalent to https://github.com/atom/autocomplete-plus/pull/1116
