### PR TITLE
deps: "downgrade" node-fetch to ^v2.6.7 in script/ (fix "Bump dependencies" job in Nightly CI)

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -2078,11 +2078,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -4078,15 +4073,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "fetch-blob": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4244,14 +4230,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "fragment-cache": {
@@ -6325,11 +6303,6 @@
         }
       }
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
     "node-emoji": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
@@ -6339,13 +6312,11 @@
       }
     },
     "node-fetch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
-        "formdata-polyfill": "^4.0.10"
+        "whatwg-url": "^5.0.0"
       }
     },
     "node-gyp-build": {
@@ -12950,11 +12921,6 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.12.tgz",
       "integrity": "sha512-HFhaD4mMWPzFSqhpyDG48KDdrjfn409YQuVW7ckZYhW4sE87mYtWifdB/+73RA7+p4s4K18n5Jfx1kHthE1gBw=="
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
     },
     "webdriver": {
       "version": "5.9.1",

--- a/script/package.json
+++ b/script/package.json
@@ -35,7 +35,7 @@
     "minidump": "^0.22.0",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
-    "node-fetch": "^3.1.1",
+    "node-fetch": "^2.6.7",
     "normalize-package-data": "2.3.5",
     "npm": "^6.14.16",
     "npm-check": "^5.9.2",


### PR DESCRIPTION
<details><summary><b>Requirements for Contributing a Bug Fix (from template, click to expand...)</b></summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

The "Bump dependencies" job of the Nightly CI pipeline has been broken since https://github.com/atom/atom/pull/23506 landed.

See my comment here: https://github.com/atom/atom/pull/23506#issuecomment-1048382944 for details.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In the script/ dir, downgrade node-fetch from 3.x to ^2.6.7.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Could properly import node-fetch 3.x as an ESM module.

I personally don't see why to go through that trouble when the 2.x branch is what we were using before, still supported, still works, even recommended for CommonJS projects such as Atom's build and CI scripts. See: https://github.com/node-fetch/node-fetch/blob/v3.2.0/docs/v3-UPGRADE-GUIDE.md#converted-to-es-module

(Link documents ESM import instructions/considerations for node-fetch v3, as part of a general node-fetch v2 to v3 migration guide.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I guess the 2.x branch of node-fetch could theoretically go out of support at some point, at which time we might wish to have done a proper migration to v3 already to overcome the breaking changes and have smoother upgrade to v3/v4/...? Unclear if this will ever be necessary. Just speculating so I have something to write under this heading.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Read some docs and interpreted error messages from Atom's CI, did some detective work... See https://github.com/atom/atom/pull/23506#issuecomment-1048382944 again for details/background that led me to this solution.

Also, this makes the "Bump dependencies" job in Nightly CI pass at my fork: https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1232&view=logs&j=6f0e81e9-e86f-5543-732c-a45afe53d8f1

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
N/A