### PR TITLE
Fix npm ENOENT error in install-script-runner-dependencies

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -72,9 +72,9 @@
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "are-we-there-yet": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+          "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,6 @@
 
 'use strict'
 
-const path = require('path')
 const CONFIG = require('./config')
 const childProcess = require('child_process')
 const cleanDependencies = require('./lib/clean-dependencies')

--- a/script/config.js
+++ b/script/config.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const spawnSync = require('./lib/spawn-sync');
 
@@ -111,14 +112,6 @@ function getApmBinPath() {
   );
 }
 
-function getNpmBinPath(external = false) {
-  const npmBinName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  const localNpmBinPath = path.resolve(
-    repositoryRootPath,
-    'script',
-    'node_modules',
-    '.bin',
-    npmBinName
-  );
-  return localNpmBinPath;
+function getNpmBinPath() {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
 }

--- a/script/config.js
+++ b/script/config.js
@@ -54,6 +54,7 @@ module.exports = {
   homeDirPath,
   getApmBinPath,
   getNpmBinPath,
+  getLocalNpmBinPath,
   snapshotAuxiliaryData: {}
 };
 
@@ -113,4 +114,16 @@ function getApmBinPath() {
 
 function getNpmBinPath() {
   return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+function getLocalNpmBinPath() {
+  const npmBinName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const localNpmBinPath = path.resolve(
+    repositoryRootPath,
+    'script',
+    'node_modules',
+    '.bin',
+    npmBinName
+  );
+  return localNpmBinPath;
 }

--- a/script/config.js
+++ b/script/config.js
@@ -3,7 +3,6 @@
 
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const spawnSync = require('./lib/spawn-sync');
 

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -12,7 +12,7 @@ module.exports = function(ci) {
   }
   console.log('Installing apm');
   childProcess.execFileSync(
-    CONFIG.getNpmBinPath(),
+    CONFIG.getLocalNpmBinPath(),
     ['--global-style', '--loglevel=error', ci ? 'ci' : 'install'],
     { env: process.env, cwd: CONFIG.apmRootPath }
   );

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -9,9 +9,8 @@ process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
 
 module.exports = function(ci) {
   console.log('Installing script dependencies');
-  const npmBinName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
   childProcess.execFileSync(
-    npmBinName,
+    CONFIG.getNpmBinPath(ci),
     ['--loglevel=error', ci ? 'ci' : 'install'],
     { env: process.env, cwd: CONFIG.scriptRootPath }
   );


### PR DESCRIPTION
### Identify the Bug

When merging atom:master to atom-community:master, https://github.com/atom-community/atom/pull/351,
there's an ENOENT error

Screenshot of https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=1132&view=logs&j=2985f0af-e798-5fdc-91b8-be9f0a3685c5&t=0a53f124-4db9-5fc3-be81-e293757effc7&l=16
![](https://user-images.githubusercontent.com/58114641/155861060-12dbe30e-0396-42c6-9bc9-c6318fcd3aa5.png)


### Description of the Change

https://github.com/atom/atom/pull/23322 causes `install-script-dependencies` to use the non-local npm binary.

So this pr fixes `install-script-runner-dependencies` (only exists in atom-community) indirectly by editing getNpmBinPath

<s>The only other use of `getNpmBinPath` is in `install-apm`. Oh, that might explain the title of that pr. If this pr fails, then</s> getNpmBinPath was changed to indirectly make `install-apm` use a local npm (which doesn't exist while `install-script-dependencies` is running). So to separate the different uses, there's a new method `getLocalNpmBinPath`.

Also updates apm/package-lock and removed an unused import.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<s>If</s> `install-apm` uses a local npm, then `getNpmBinPath` and `getLocalNpmBinPath` would only be used once.

In this case, the methods might be better located in the same file or inlined within the functions.

### Verification Process

- [x] No ENOENT errors when I make this change in a branch of atom-community similar to https://github.com/atom-community/atom/pull/351