### PR TITLE
Parse to ecmaVersion 10

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
   },
   "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 8,
+    "ecmaVersion": 10,
     "ecmaFeatures": {
       "jsx": true
     }


### PR DESCRIPTION
### Description of the change

https://github.com/eslint/eslint/blob/5.x/docs/user-guide/configuring.md shows that `ecmaVersion 10` (2019) is the latest version supported by eslint 5

Since [electron was updated](https://github.com/atom/atom/blob/d016186110ffbe588a45d594803f9f9078804085/package.json#L15) [to version 11](https://github.com/electron/electron/releases/tag/v11.0.0), which uses [v8 release 87 (2020)](https://v8.dev/blog/v8-release-87), this seems to be supported.

### Benefits

Less code / faster code in general since there's less polyfills?

### Drawbacks

### Verification

If the tests build atom

### Release notes

Parse to `ecmaVersion 10` (2019)
