### PR TITLE
Bump 7zip-bin from 4.0.2 to 5.1.1 in /script

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "7zip-bin": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.0.2.tgz",
-      "integrity": "sha512-XtGk+IF57pr852UK1AhQJXqmm1WmSgS5uISL+LPs0z/iAxXouMvdlLJrHPeukP6gd7yR2rDTMSMkHNODgwIq7A=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz",
+      "integrity": "sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ=="
     },
     "@atom/electron-winstaller": {
       "version": "0.0.1",

--- a/script/package.json
+++ b/script/package.json
@@ -2,7 +2,7 @@
   "name": "atom-build-scripts",
   "description": "Atom build scripts",
   "dependencies": {
-    "7zip-bin": "^4.0.2",
+    "7zip-bin": "^5.1.1",
     "@atom/electron-winstaller": "0.0.1",
     "@octokit/request": "^5.4.5",
     "async": "^3.2.0",


### PR DESCRIPTION
Bumps https://github.com/develar/7zip-bin to 5.1.1 in /script

Edit: It failed because of a brownout