### PR TITLE
:bug: Fix parsing of DESKTOP_SESSION to check for cinnamon

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -2,7 +2,7 @@
 
 if [ "$(uname)" == 'Darwin' ]; then
   OS='Mac'
-elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
+elif [ "$(expr substr "$(uname -s)" 1 5)" == 'Linux' ]; then
   OS='Linux'
 else
   echo "Your platform ($(uname -a)) is not supported."
@@ -151,7 +151,7 @@ if [ $OS == 'Mac' ]; then
   fi
 elif [ $OS == 'Linux' ]; then
   SCRIPT=$(readlink -f "$0")
-  USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
+  USR_DIRECTORY=$(readlink -f "$(dirname $SCRIPT)"/..)
 
   case $CHANNEL in
     beta)
@@ -169,7 +169,7 @@ elif [ $OS == 'Linux' ]; then
   esac
 
   #Will allow user to get context menu on cinnamon desktop enviroment
-  if [[ "$(expr substr $(printenv | grep "DESKTOP_SESSION=") 17 8)" == "cinnamon" ]]; then
+  if [[ "$(expr substr "$(printenv | grep "DESKTOP_SESSION=")" 17 8)" == "cinnamon" ]]; then
     cp "resources/linux/desktopenviroment/cinnamon/atom.nemo_action" "/usr/share/nemo/actions/atom.nemo_action"
   fi
 


### PR DESCRIPTION
### Identify the Bug

See [Issue #23733](https://github.com/atom/atom/issues/23733).

### Description of the Change

Adds nested quoting in `script.sh` for the source of the issue referenced above on [line 172 of `atom.sh`](https://github.com/atom/atom/blob/41234da15e193db04f2269f7ecf8e9271db193c2/atom.sh#L172).

Also adds similar quoting to all other places that ShellCheck warns of potential issues with unintended splitting of results due to whitespace.

### Alternate Designs

Since the the error in issue 23733 only happens when the `grep` fails to match, the intended behavior still occurs. Therefore, it would be possible to squelch the error message by redirecting stderr to `/dev/null`. However, this would literally address the symptoms instead of the root cause - the error message is indicating an actual failure of the negative test case to function as intended. Correcting that failure seems like the way to go.

### Possible Drawbacks

None that I'm aware of. Quoting of this sort should be valid on any version of `bash` that would accept `$()` syntax, and its introduction here (in all cases) appears to ensure what was intended happens in more edge cases rather than change the intended behavior.

### Verification Process

I did not see any shell script test suites that would have applied to `atom.sh` so I tested it manually via
- Shellcheck testing of the updated script (`shellcheck atom.sh`)
- Copying the updated code to `/usr/bin/atom` for an install of version `1.60.0` on Mint Linux 20.2 (based on Ubuntu `20.04`) for x64 and running it through several test cases.
    - When `DESKTOP_SESSION=cinnamon` Atom starts (or a new window is opened), no error message appeared and the file copy on line 173 was attempted.
    - When `DESKTOP_SESSION` is unset or equal to anything else, Atom starts (or a new window is opened) , no error message appeared and the file copy on line 173 was _not_ attempted.

### Release Notes

Fixed syntax error message when running atom from CLI on mac/linux

### Additional Comments

Shellcheck reports another warning-level issue that seemed worth ignoring - that there is no default case in the `getopts` case statement. Depending on how it was done, addressing this warning could introduce a behavioral change where the script stops silently accepting options it will not act upon.