### PR TITLE
Fix usage message (closes #25441)

### DIFF
--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -12,15 +12,10 @@ const CSON = require('season');
 const yargs = require('yargs');
 const { app } = require('electron');
 
-const version = `Atom    : ${app.getVersion()}
-Electron: ${process.versions.electron}
-Chrome  : ${process.versions.chrome}
-Node    : ${process.versions.node}`;
-
 const args = yargs(process.argv)
-  .alias('v', 'version')
-  .version(version)
+  // Don't handle --help or --version here; they will be handled later.
   .help(false)
+  .version(false)
   .alias('d', 'dev')
   .alias('t', 'test')
   .alias('r', 'resource-path').argv;

--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -20,6 +20,7 @@ Node    : ${process.versions.node}`;
 const args = yargs(process.argv)
   .alias('v', 'version')
   .version(version)
+  .help(false)
   .alias('d', 'dev')
   .alias('t', 'test')
   .alias('r', 'resource-path').argv;

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -133,7 +133,16 @@ module.exports = function parseCommandLine(processArgs) {
       'Enable low-level logging messages from Electron.'
     );
   options.boolean('uri-handler');
+  options
+    .version(
+      dedent`Atom    : ${version}
+             Electron: ${process.versions.electron}
+             Chrome  : ${process.versions.chrome}
+             Node    : ${process.versions.node}`
+    )
+    .alias('v', 'version');
 
+  // NB: if --help or --version are given, this also displays the relevant message and exits
   let args = options.argv;
 
   // If --uri-handler is set, then we parse NOTHING else

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -57,10 +57,7 @@ module.exports = function parseCommandLine(processArgs) {
     .alias('f', 'foreground')
     .boolean('f')
     .describe('f', 'Keep the main process in the foreground.');
-  options
-    .alias('h', 'help')
-    .boolean('h')
-    .describe('h', 'Print this usage message.');
+  options.help('help', 'Print this usage message.').alias('h', 'help');
   options
     .alias('l', 'log-file')
     .string('l')
@@ -146,11 +143,6 @@ module.exports = function parseCommandLine(processArgs) {
       'uri-handler': true,
       _: args._.filter(str => str.startsWith('atom://')).slice(0, 1)
     };
-  }
-
-  if (args.help) {
-    process.stdout.write(options.help());
-    process.exit(0);
   }
 
   const addToLastWindow = args['add'];

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -37,15 +37,18 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
     }
   });
 
-  const previousConsoleLog = console.log;
-  console.log = nslog;
-
   // TodoElectronIssue this should be set to true before Electron 12 - https://github.com/electron/electron/issues/18397
   app.allowRendererProcessReuse = false;
 
   app.commandLine.appendSwitch('enable-experimental-web-platform-features');
 
   const args = parseCommandLine(process.argv.slice(1));
+
+  // This must happen after parseCommandLine() because yargs uses console.log
+  // to display the usage message.
+  const previousConsoleLog = console.log;
+  console.log = nslog;
+
   args.resourcePath = normalizeDriveLetterName(resourcePath);
   args.devResourcePath = normalizeDriveLetterName(devResourcePath);
 


### PR DESCRIPTION
### Identify the Bug

This fixes #25441.

### Description of the Change

The commit should be self explanatory, but the summary is:
- `atom -h` produces actual output
- `atom --help` produces correct output
- `atom -h` and `atom --help` both produce the same output
- the description (in the usage message) for `-h/--help` is corrected
- `-v/--version` are correctly included in the usage message

### Alternate Designs

I did not consider alternate designs b/c these fixes were pretty straightforward.

### Possible Drawbacks

None that I can think of. This only corrects defects.

### Verification Process

I have built and tested this locally, by hand.

### Release Notes

When launched from the CLI, the `-h` and `--help` flags will now display the correct usage message.
