### PR TITLE
New "Open Package Manager" menu item

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -196,7 +196,10 @@
 
   {
     label: 'Packages'
-    submenu: []
+    submenu: [
+      { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }
+      { type: 'separator' }
+    ]
   }
 
   {

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -178,8 +178,11 @@
   }
 
   {
-    label: '&Packages'
-    submenu: []
+    label: 'Packages'
+    submenu: [
+      { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }
+      { type: 'separator' }
+    ]
   }
 
   {

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -178,7 +178,7 @@
   }
 
   {
-    label: 'Packages'
+    label: '&Packages'
     submenu: [
       { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }
       { type: 'separator' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -177,8 +177,11 @@
   }
 
   {
-    label: '&Packages'
-    submenu: []
+    label: 'Packages'
+    submenu: [
+      { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }
+      { type: 'separator' }
+    ]
   }
 
   {

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -177,7 +177,7 @@
   }
 
   {
-    label: 'Packages'
+    label: '&Packages'
     submenu: [
       { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }
       { type: 'separator' }


### PR DESCRIPTION
### Issue
This fixes #20278

### Description of the Change
This adds a menu item called "Open Package Manager" under the menu "Packages" that opens Settings > Packages installed

### Verification Process
We verified that the new item appers and works on all platforms.

### Release Notes
- New "Open Package Manager" menu item

