### PR TITLE
Remove requirement "lsb-core-noarch" from the RPM spec file.

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -8,9 +8,9 @@ AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
 %ifarch i386 i486 i586 i686
-Requires: alsa-lib, git-core, (glib2 or kde-cli-tools or xdg-utils), lsb-core-noarch, (libcurl.so.3 or libcurl.so.4), libgbm.so.1, libgcrypt.so.20, libnotify, libnss3.so, libX11-xcb.so.1, libxcb-dri3.so.0, libxkbfile.so.1, libXss.so.1, libsecret-1.so.0, gtk3, polkit
+Requires: alsa-lib, git-core, (glib2 or kde-cli-tools or xdg-utils), (libcurl.so.3 or libcurl.so.4), libgbm.so.1, libgcrypt.so.20, libnotify, libnss3.so, libX11-xcb.so.1, libxcb-dri3.so.0, libxkbfile.so.1, libXss.so.1, libsecret-1.so.0, gtk3, polkit
 %else
-Requires: alsa-lib, git-core, (glib2 or kde-cli-tools or xdg-utils), lsb-core-noarch, (libcurl.so.3()(64bit) or libcurl.so.4()(64bit)), libgbm.so.1()(64bit), libgcrypt.so.20()(64bit), libnotify, libnss3.so()(64bit), libX11-xcb.so.1()(64bit), libxcb-dri3.so.0()(64bit), libxkbfile.so.1()(64bit), libXss.so.1()(64bit), libsecret-1.so.0()(64bit), gtk3, polkit
+Requires: alsa-lib, git-core, (glib2 or kde-cli-tools or xdg-utils), (libcurl.so.3()(64bit) or libcurl.so.4()(64bit)), libgbm.so.1()(64bit), libgcrypt.so.20()(64bit), libnotify, libnss3.so()(64bit), libX11-xcb.so.1()(64bit), libxcb-dri3.so.0()(64bit), libxkbfile.so.1()(64bit), libXss.so.1()(64bit), libsecret-1.so.0()(64bit), gtk3, polkit
 %endif
 
 # Disable Fedora's shebang mangling script,


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

See #23560.
The dependency `lsb-core-noarch` is not (properly) supported anymore by many distributions and leads to completely unnecessary and deprecated (e.g. Python 2 on openSUSE Tumbleweed) dependencies. Packages should instead define the minimal requirements they actually have.

### Description of the Change

The requirement `lsb-core-noarch` was removed from the RPM spec file.

### Alternate Designs

See #23560 for alternative solutions.

### Possible Drawbacks

A dependency of atom may not be required by the RPM anymore.

### Verification Process

None, besides an educated guess that the base system requirements are already installed by default. (I could not find documentation on building the package locally, and `./script/build --create-rpm-package` failed on installing the script dependencies.)

### Release Notes

Dropped the `lsb-core-noarch` requirement from the RPM.