### PR TITLE
Add lsb_release file to "Recommends:" of rpm spec

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -13,6 +13,8 @@ Requires: alsa-lib, git-core, (glib2 or kde-cli-tools or xdg-utils), (libcurl.so
 Requires: alsa-lib, git-core, (glib2 or kde-cli-tools or xdg-utils), (libcurl.so.3()(64bit) or libcurl.so.4()(64bit)), libgbm.so.1()(64bit), libgcrypt.so.20()(64bit), libnotify, libnss3.so()(64bit), libX11-xcb.so.1()(64bit), libxcb-dri3.so.0()(64bit), libxkbfile.so.1()(64bit), libXss.so.1()(64bit), libsecret-1.so.0()(64bit), gtk3, polkit
 %endif
 
+Recommends: /usr/bin/lsb_release
+
 # Disable Fedora's shebang mangling script,
 # which errors out on any file with versionless `python` in its shebang
 # See: https://github.com/atom/atom/issues/21937


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (From template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

Following up on https://github.com/atom/atom/pull/25541

### Description of the Change

Actually add `/usr/bin/lsb_release` to th dependencies in the rpm spec file, as was originally intended in https://github.com/atom/atom/pull/25541.

This helps the bug report feature of the "notifications" package include more system info on Linux systems -- if /usr/bin/lsb_release is available, it will be called to gather some basic OS info to add to the bug report info. (See https://github.com/atom/notifications/pull/64 for implementation details and discussion there at the time this feature was added.)

(This PR is to implement a fix that was intended to be a part of https://github.com/atom/atom/pull/25541. See discussion in that PR for background.)

### Alternate Designs

See discussion in https://github.com/atom/atom/pull/25541.

- Could be added to `Requires:` instead of `Recommends:`.

That would make it a "hard requirement". `Recommends:` installs it by default, if possible, otherwise skips it with no problem.

I added `/usr/lib/lsb_release` to `Recommends:` instead, so users in the future can proceed without the `/usr/lib/lsb_release` binary if they can't install it, but it will be installed by default.

The notifications package will use `lsb_release` if it can, but it has fallback behavior if you don't have it, so I think this is the most appropriate choice?

### Possible Drawbacks

None? See "Alternate Designs" above.

### Verification Process

Please wait for CI to complete and build an RPM file.

I can then attempt to install it in a Fedora Docker container and see how it goes.

### Release Notes

Fix: Actually add `/usr/lib/lsb_release` to the dependencies in the rpm spec file.