### PR TITLE
Fixes failing CI

### DIFF
--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -14,7 +14,7 @@ jobs:
           RunCoreMainTests: true
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
 
     variables:
       AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]


### PR DESCRIPTION
* The CI currently fails due to the following 
  -  An outdated windows image
  -  Rate limiting on the GitHub API
  