### PR TITLE
Create new view to announce we're sunsetting Atom

### DIFF
--- a/packages/welcome/docs/events.md
+++ b/packages/welcome/docs/events.md
@@ -14,23 +14,29 @@ Currently the Welcome package does not log any timing events.
 
 #### Welcome package shown
 
-* **eventType**: `welcome-v1`
-* **metadata**
+- **eventType**: `welcome-v1`
+- **metadata**
 
-  | field | value |
-  |-------|-------|
-  | `ea` | `show-on-initial-load`
+  | field | value                  |
+  | ----- | ---------------------- |
+  | `ea`  | `show-on-initial-load` |
 
+#### Sunsetting announcement shown
+
+- **eventType**: `sunsetting-v1`
+- **metadata**
+
+  | field | value                             |
+  | ----- | --------------------------------- |
+  | `ea`  | `show-sunsetting-on-initial-load` |
 
 #### Click on links
 
-* **eventType**: `welcome-v1`
-* **metadata**
+- **eventType**: `welcome-v1`
+- **metadata**
 
-  | field | value |
-  |-------|-------|
-  | `ea` | link that was clicked
+  | field | value                 |
+  | ----- | --------------------- |
+  | `ea`  | link that was clicked |
 
 (There are many potential values for the `ea` param, e.g: `clicked-welcome-atom-docs-link`,`clicked-welcome-atom-org-link`, `clicked-project-cta`, `clicked-init-script-cta`, ...).
-
-

--- a/packages/welcome/lib/sunsetting-view.js
+++ b/packages/welcome/lib/sunsetting-view.js
@@ -93,8 +93,8 @@ export default class SunsettingView {
 
           <section className="welcome-panel">
             <p>
-              We are archiving Atom and all projects under the Atom organization
-              for an official sunset on December 15, 2022.
+              We are archiving Atom and all repositories under the Atom
+              organization for an official sunset on December 15, 2022.
             </p>
             <p>
               You can learn more about this in our{' '}
@@ -113,7 +113,7 @@ export default class SunsettingView {
                 checked={atom.config.get('welcome.showSunsettingOnStartup')}
                 onchange={this.didChangeShowOnStartup}
               />
-              Show this announce when opening Atom
+              Show this announcement when opening Atom
             </label>
           </section>
 

--- a/packages/welcome/lib/sunsetting-view.js
+++ b/packages/welcome/lib/sunsetting-view.js
@@ -3,7 +3,7 @@
 
 import etch from 'etch';
 
-export default class WelcomeView {
+export default class SunsettingView {
   constructor(props) {
     this.props = props;
     etch.initialize(this);
@@ -12,21 +12,21 @@ export default class WelcomeView {
       const link = event.target.closest('a');
       if (link && link.dataset.event) {
         this.props.reporterProxy.sendEvent(
-          `clicked-welcome-${link.dataset.event}-link`
+          `clicked-sunsetting-${link.dataset.event}-link`
         );
       }
     });
   }
 
   didChangeShowOnStartup() {
-    atom.config.set('welcome.showOnStartup', this.checked);
+    atom.config.set('welcome.showSunsettingOnStartup', this.checked);
   }
 
   update() {}
 
   serialize() {
     return {
-      deserializer: 'WelcomeView',
+      deserializer: 'SunsettingView',
       uri: this.props.uri,
     };
   }
@@ -36,7 +36,7 @@ export default class WelcomeView {
       <div className="welcome">
         <div className="welcome-container">
           <header className="welcome-header">
-            <a href="https://atom.io/">
+            <a href="https://github.blog/2022-06-08-sunsetting-atom/">
               <svg
                 className="welcome-logo"
                 width="330px"
@@ -87,45 +87,22 @@ export default class WelcomeView {
                   </g>
                 </g>
               </svg>
-              <h1 className="welcome-title">
-                A hackable text editor for the 21<sup>st</sup> Century
-              </h1>
+              <h1 className="welcome-title">We are sunsetting Atom</h1>
             </a>
           </header>
 
           <section className="welcome-panel">
-            <p>For help, please visit</p>
-            <ul>
-              <li>
-                The{' '}
-                <a
-                  href="https://www.atom.io/docs"
-                  dataset={{ event: 'atom-docs' }}
-                >
-                  Atom docs
-                </a>{' '}
-                for Guides and the API reference.
-              </li>
-              <li>
-                The Atom forum at{' '}
-                <a
-                  href="https://github.com/atom/atom/discussions"
-                  dataset={{ event: 'discussions' }}
-                >
-                  Github Discussions
-                </a>
-              </li>
-              <li>
-                The{' '}
-                <a
-                  href="https://github.com/atom"
-                  dataset={{ event: 'atom-org' }}
-                >
-                  Atom org
-                </a>
-                . This is where all GitHub-created Atom packages can be found.
-              </li>
-            </ul>
+            <p>
+              We are archiving Atom and all projects under the Atom organization
+              for an official sunset on December 15, 2022.
+            </p>
+            <p>
+              You can learn more about this in our{' '}
+              <a href="https://github.blog/2022-06-08-sunsetting-atom/">
+                blog post
+              </a>
+              .
+            </p>
           </section>
 
           <section className="welcome-panel">
@@ -133,10 +110,10 @@ export default class WelcomeView {
               <input
                 className="input-checkbox"
                 type="checkbox"
-                checked={atom.config.get('welcome.showOnStartup')}
+                checked={atom.config.get('welcome.showSunsettingOnStartup')}
                 onchange={this.didChangeShowOnStartup}
               />
-              Show Welcome Guide when opening Atom
+              Show this announce when opening Atom
             </label>
           </section>
 
@@ -161,10 +138,10 @@ export default class WelcomeView {
   }
 
   getTitle() {
-    return 'Welcome';
+    return 'Sunsetting Atom';
   }
 
   isEqual(other) {
-    return other instanceof WelcomeView;
+    return other instanceof SunsettingView;
   }
 }

--- a/packages/welcome/lib/welcome-package.js
+++ b/packages/welcome/lib/welcome-package.js
@@ -74,7 +74,6 @@ export default class WelcomePackage {
   showWelcome() {
     return Promise.all([
       atom.workspace.open(WELCOME_URI, { split: 'left' }),
-      atom.workspace.open(SUNSETTING_URI, { split: 'left' }),
       atom.workspace.open(GUIDE_URI, { split: 'right' }),
     ]);
   }

--- a/packages/welcome/lib/welcome-package.js
+++ b/packages/welcome/lib/welcome-package.js
@@ -3,8 +3,9 @@
 import { CompositeDisposable } from 'atom';
 import ReporterProxy from './reporter-proxy';
 
-let WelcomeView, GuideView, ConsentView;
+let WelcomeView, GuideView, ConsentView, SunsettingView;
 
+const SUNSETTING_URI = 'atom://welcome/sunsetting';
 const WELCOME_URI = 'atom://welcome/welcome';
 const GUIDE_URI = 'atom://welcome/guide';
 const CONSENT_URI = 'atom://welcome/consent';
@@ -18,7 +19,15 @@ export default class WelcomePackage {
     this.subscriptions = new CompositeDisposable();
 
     this.subscriptions.add(
-      atom.workspace.addOpener(filePath => {
+      atom.workspace.addOpener((filePath) => {
+        if (filePath === SUNSETTING_URI) {
+          return this.createSunsettingView({ uri: SUNSETTING_URI });
+        }
+      })
+    );
+
+    this.subscriptions.add(
+      atom.workspace.addOpener((filePath) => {
         if (filePath === WELCOME_URI) {
           return this.createWelcomeView({ uri: WELCOME_URI });
         }
@@ -26,7 +35,7 @@ export default class WelcomePackage {
     );
 
     this.subscriptions.add(
-      atom.workspace.addOpener(filePath => {
+      atom.workspace.addOpener((filePath) => {
         if (filePath === GUIDE_URI) {
           return this.createGuideView({ uri: GUIDE_URI });
         }
@@ -34,7 +43,7 @@ export default class WelcomePackage {
     );
 
     this.subscriptions.add(
-      atom.workspace.addOpener(filePath => {
+      atom.workspace.addOpener((filePath) => {
         if (filePath === CONSENT_URI) {
           return this.createConsentView({ uri: CONSENT_URI });
         }
@@ -42,7 +51,9 @@ export default class WelcomePackage {
     );
 
     this.subscriptions.add(
-      atom.commands.add('atom-workspace', 'welcome:show', () => this.show())
+      atom.commands.add('atom-workspace', 'welcome:show', () =>
+        this.showWelcome()
+      )
     );
 
     if (atom.config.get('core.telemetryConsent') === 'undecided') {
@@ -50,16 +61,26 @@ export default class WelcomePackage {
     }
 
     if (atom.config.get('welcome.showOnStartup')) {
-      await this.show();
+      await this.showWelcome();
       this.reporterProxy.sendEvent('show-on-initial-load');
+    }
+
+    if (atom.config.get('welcome.showSunsettingOnStartup')) {
+      await this.showSunsetting();
+      this.reporterProxy.sendEvent('show-sunsetting-on-initial-load');
     }
   }
 
-  show() {
+  showWelcome() {
     return Promise.all([
       atom.workspace.open(WELCOME_URI, { split: 'left' }),
-      atom.workspace.open(GUIDE_URI, { split: 'right' })
+      atom.workspace.open(SUNSETTING_URI, { split: 'left' }),
+      atom.workspace.open(GUIDE_URI, { split: 'right' }),
     ]);
+  }
+
+  showSunsetting() {
+    return atom.workspace.open(SUNSETTING_URI, { split: 'left' });
   }
 
   consumeReporter(reporter) {
@@ -68,6 +89,11 @@ export default class WelcomePackage {
 
   deactivate() {
     this.subscriptions.dispose();
+  }
+
+  createSunsettingView(state) {
+    if (SunsettingView == null) SunsettingView = require('./sunsetting-view');
+    return new SunsettingView({ reporterProxy: this.reporterProxy, ...state });
   }
 
   createWelcomeView(state) {

--- a/packages/welcome/package.json
+++ b/packages/welcome/package.json
@@ -25,6 +25,11 @@
       "type": "boolean",
       "default": true,
       "description": "Show welcome panes with useful information when opening a new Atom window."
+    },
+    "showSunsettingOnStartup": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show sunsetting pane when opening a new Atom window."
     }
   },
   "deserializers": {

--- a/packages/welcome/package.json
+++ b/packages/welcome/package.json
@@ -35,7 +35,8 @@
   "deserializers": {
     "WelcomeView": "createWelcomeView",
     "GuideView": "createGuideView",
-    "ConsentView": "createConsentView"
+    "ConsentView": "createConsentView",
+    "SunsettingView": "createSunsettingView"
   },
   "dependencies": {
     "etch": "0.9.0"


### PR DESCRIPTION
### Description of the Change

This PR adds a "welcome" tab with the announcement about Atom being sunset. See https://github.blog/2022-06-08-sunsetting-atom/

This new "welcome" tab will be focused when the app starts and can be skipped via a checkbox included in the very same tab.

![image](https://user-images.githubusercontent.com/1083228/193543163-41d0c2b4-efd4-48ed-902e-5b021b321cd8.png)

(Note: the text has changed a bit since that screenshot was taken… see [e522312](https://github.com/atom/atom/pull/25632/commits/e522312ffadbe4833f4d902b682b1f6940629910))

### Verification Process

1. Open the app for the first time on this build and check you get the new announcement tab and it's focused.
2. Open the app with a previous version, do some work, then upgrade to this build, and check you get the new announcement tab and it's focused.
3. Check that opening the app again, still gets you the new announcement tab and it's focused.
4. Uncheck the "Show this announcement when opening Atom" toggle, close the app and open it again. Check that you don't get that new announcement tab anymore.

### Release Notes

Add announcement about Atom being sunset on December 15, 2022

-----
[View rendered packages/welcome/docs/events.md](https://github.com/sergiou87/atom/blob/sunsetting-announcement/packages/welcome/docs/events.md)