### PR TITLE
fix link on CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-See https://atom.io/releases
+See https://github.com/atom/atom/releases


### PR DESCRIPTION
Fix the link on the CHANGELOG which displayed a 404 error


-----
[View rendered CHANGELOG.md](https://github.com/coliff/atom/blob/patch-1/CHANGELOG.md)