### PR TITLE
references to community forks

### DIFF
--- a/packages/welcome/lib/sunsetting-view.js
+++ b/packages/welcome/lib/sunsetting-view.js
@@ -103,6 +103,17 @@ export default class SunsettingView {
               </a>
               .
             </p>
+            <p>
+               You can also check out the community forks from
+               <a href="https://github.com/atom-community/atom">
+                 atom-community
+              </a>
+              or
+               <a href="https://github.com/pulsar-edit/pulsar">
+                 pulsar-edit
+              </a>
+              .
+            </p>
           </section>
 
           <section className="welcome-panel">


### PR DESCRIPTION
This adds references to community forks for people that want to continue using there loved editor.
The community forks mentioned are from [atom-community](https://github.com/atom-community/atom) (mostly maintenance) and from [pulsar-edit](https://github.com/pulsar-edit/pulsar) (goal to modernize).