### PR TITLE
Fix `File` -> `Open…` menu on macOS

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -322,10 +322,20 @@ module.exports = function(packagedAppPath) {
 
     const snapshotBinaries = ['v8_context_snapshot.bin', 'snapshot_blob.bin'];
     for (let snapshotBinary of snapshotBinaries) {
-      const destinationPath = path.join(
+      let destinationPath = path.join(
         startupBlobDestinationPath,
         snapshotBinary
       );
+      if (
+        process.platform === 'darwin' &&
+        snapshotBinary === 'v8_context_snapshot.bin'
+      ) {
+        // TODO: check if we're building for arm64 and use the arm64 version of the binary
+        destinationPath = path.join(
+          startupBlobDestinationPath,
+          'v8_context_snapshot.x86_64.bin'
+        );
+      }
       console.log(`Moving generated startup blob into "${destinationPath}"`);
       try {
         fs.unlinkSync(destinationPath);


### PR DESCRIPTION
1.63 introduced a regression on the `File` -> `Open…` menu because Electron 10-11 changed how v8 snapshot files are named on macOS: they now have a `x86_64` or `arm64` suffix depending on the platform they're built for.

Due to that the [`getDefaultPath` function in the main process](https://github.com/atom/atom/blob/3fb9d4dd116ed45aab41c02800c1156ad5c245c8/src/main-process/atom-application.js#L43) doesn't have a valid value for the global `atom` variable, which is actually set from that snapshot.

It is not really necessary, since the main process cannot access any of the editor stuff, so that function could just remove `undefined` and that's it. However we wanted to make sure we used the snapshot file as it improves the launch time of the app.

Props to @niik for finding out the reason behind this obscure bug, I didn't even know Electron could do this v8 snapshot magic 😂 👏 