### PR TITLE
Update atom.sh

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -169,7 +169,7 @@ elif [ $OS == 'Linux' ]; then
   esac
 
   #Will allow user to get context menu on cinnamon desktop enviroment
-  if [[ "$(expr substr $(printenv | grep "DESKTOP_SESSION=") 17 8)" == "cinnamon" ]]; then
+  if [[ "$(expr substr "$(printenv | grep "DESKTOP_SESSION=")" 17 8)" == "cinnamon" ]]; then
     cp "resources/linux/desktopenviroment/cinnamon/atom.nemo_action" "/usr/share/nemo/actions/atom.nemo_action"
   fi
 


### PR DESCRIPTION
### Identify the Bug

https://github.com/atom/atom/issues/25740

### Description of the Change

by quoting the result of $(...) it is taken as empty string so that substring command gets the right amount of parameter

### Alternate Designs

non

### Possible Drawbacks

non

### Verification Process

Using shellcheck confirms the change. Starting atom after the change works flawless with and without 'DESKTOP_SESSION' defined.

### Release Notes

Fix error message in case DESKTOP_SESSION is not defined